### PR TITLE
Enable sending items from triggers, futures, etc. via platform events

### DIFF
--- a/force-app/main/default/classes/DataBuilder.cls
+++ b/force-app/main/default/classes/DataBuilder.cls
@@ -3,19 +3,14 @@ public with sharing class DataBuilder {
         this.config = config;
     }
 
-    public Map<String, Object> buildPayload(String level, String message)
+    public Map<String, Object> buildPayload(String level, String message, Map<String, Object> custom)
     {
-        return buildPayloadStructure(level, buildMessageBody(message), null);
+        return buildPayloadStructure(level, buildMessageBody(message), custom);
     }
 
-    public Map<String, Object> buildPayload(Exception exc)
+    public Map<String, Object> buildPayload(String level, Exception exc, Map<String, Object> custom)
     {
-        return buildPayloadStructure('error', buildExceptionBody(exc), null);
-    }
-
-    public Map<String, Object> buildPayload(Exception exc, Map<String, Object> custom)
-    {
-        return buildPayloadStructure('error', buildExceptionBody(exc), custom);
+        return buildPayloadStructure(level, buildExceptionBody(exc), custom);
     }
 
     public Map<String, Object> buildPayload(ExceptionData exData)
@@ -52,14 +47,14 @@ public with sharing class DataBuilder {
     }
 
     private Map<String, Object> buildPayloadStructure(
-        String level, 
-        Map<String, Object> body, 
+        String level,
+        Map<String, Object> body,
         Map<String, Object> custom
     ) {
         Map<String, Object> data = this.buildDataStructure(
-            level, 
-            this.config.environment(), 
-            body, 
+            level,
+            this.config.environment(),
+            body,
             custom
         );
 
@@ -75,7 +70,7 @@ public with sharing class DataBuilder {
         Map<String, Object> body,
         Map<String, Object> custom
     ) {
-        
+
         Map<String, Object> notifierMap = new Map<String, Object>();
         notifierMap.put('name', Notifier.NAME);
         notifierMap.put('version', Notifier.VERSION);
@@ -118,7 +113,7 @@ public with sharing class DataBuilder {
         Map<String, Object> excMap = new Map<String, Object>();
         excMap.put('class', exData.className());
         excMap.put('message', exData.message());
-        
+
         return buildTraceStructure(excMap, framesList);
     }
 

--- a/force-app/main/default/classes/Notifier.cls
+++ b/force-app/main/default/classes/Notifier.cls
@@ -9,32 +9,61 @@ public with sharing class Notifier
         this.dataBuilder = new DataBuilder(this.config);
     }
 
-    public HttpResponse log(String level, String message)
+    public HttpResponse log(String level, String message, Map<String, Object> custom, SendMethod method)
     {
-        return send(dataBuilder.buildPayload(level, message));
+        return send(dataBuilder.buildPayload(level, message, custom), method);
     }
 
-    public HttpResponse log(Exception exc)
+    public HttpResponse log(String level, Exception exc, Map<String, Object> custom, SendMethod method)
     {
-        return send(dataBuilder.buildPayload(exc));
+        return send(dataBuilder.buildPayload(level, exc, custom), method);
     }
 
-    public HttpResponse log(Exception exc, Map<String, Object> custom)
+    public HttpResponse log(ExceptionData exData, SendMethod method)
     {
-        return send(dataBuilder.buildPayload(exc, custom));
+        return send(dataBuilder.buildPayload(exData), method);
     }
 
-    public HttpResponse log(ExceptionData exData)
+    public HttpResponse send(Map<String, Object> payload, SendMethod method)
     {
-        return send(dataBuilder.buildPayload(exData));
+        return methodSend(JSON.serialize(payload), method);
     }
 
-    private HttpResponse send(Map<String, Object> payload)
+    public HttpResponse methodSend(String payload, SendMethod method)
     {
-        return send(JSON.serialize(payload));
+        HttpResponse response = null;
+
+        switch on method {
+            when SYNC {
+                response = syncSend(payload);
+            }
+            when FUTURE {
+                Notifier.futureSend(payload);
+            }
+            when else {
+                eventSend(payload);
+            }
+        }
+
+        return response;
     }
 
-    private HttpResponse send(String payload)
+    private void eventSend(String payload)
+    {
+        RollbarEvent__e event = new RollbarEvent__e(Data1__c = payload);
+
+        EventBus.publish(event);
+    }
+
+    @future (callout=true)
+    private static void futureSend(String payload)
+    {
+        Notifier notifier = Rollbar.initializedInstance().notifier();
+
+        notifier.syncSend(payload);
+    }
+
+    private HttpResponse syncSend(String payload)
     {
         HttpRequest request = new HttpRequest();
         request.setEndpoint(this.config.endpoint());

--- a/force-app/main/default/classes/Rollbar.cls
+++ b/force-app/main/default/classes/Rollbar.cls
@@ -41,26 +41,45 @@ global with sharing class Rollbar {
     }
 
     global static HttpResponse log(String level, String message) {
+        return log(level, message, null, null);
+    }
+
+    global static HttpResponse log(String level, String message, Map<String, Object> custom) {
+        return log(level, message, custom, null);
+    }
+
+    global static HttpResponse log(String level, String message, SendMethod method) {
+        return log(level, message, null, method);
+    }
+
+    global static HttpResponse log(String level, String message, Map<String, Object> custom, SendMethod method) {
         Rollbar instance = initializedInstance();
-        return instance.notifier.log(level, message);
+        return instance.notifier.log(level, message, custom, method);
     }
 
     global static HttpResponse log(Exception exc) {
-        Rollbar instance = initializedInstance();
-        return instance.notifier.log(exc);
+        return log(exc, null, null);
+    }
+
+    global static HttpResponse log(Exception exc, SendMethod method) {
+        return log(exc, null, method);
     }
 
     global static HttpResponse log(Exception exc, Map<String, Object> custom) {
+        return log(exc, custom, null);
+    }
+
+    global static HttpResponse log(Exception exc, Map<String, Object> custom, SendMethod method) {
         Rollbar instance = initializedInstance();
-        return instance.notifier.log(exc, custom);
+        return instance.notifier.log('error', exc, custom, method);
     }
 
     global static HttpResponse log(ExceptionData exData) {
         Rollbar instance = initializedInstance();
-        return instance.notifier.log(exData);
+        return instance.notifier.log(exData, SendMethod.SYNC);
     }
 
-    private static Rollbar initializedInstance()
+    public static Rollbar initializedInstance()
     {
         Rollbar instance = Rollbar.instance();
         if (!instance.initialized) {
@@ -71,6 +90,10 @@ global with sharing class Rollbar {
     }
 
     private Rollbar() {
+    }
+
+    public Notifier notifier() {
+        return notifier;
     }
 
     private static Rollbar instance = null;

--- a/force-app/main/default/classes/RollbarInstaller.cls
+++ b/force-app/main/default/classes/RollbarInstaller.cls
@@ -176,7 +176,7 @@ public with sharing class RollbarInstaller {
     public static Boolean accessTokenCorrect(Config config)
     {
         Rollbar.init(config);
-        System.HttpResponse response = Rollbar.log('info', 'Rollbar Apex SDK installed correctly in ' + UserInfo.getOrganizationName());
+        System.HttpResponse response = Rollbar.log('info', 'Rollbar Apex SDK installed correctly in ' + UserInfo.getOrganizationName(), SendMethod.SYNC);
         return response.getStatusCode() == 200;
     }
 

--- a/force-app/main/default/classes/SendMethod.cls
+++ b/force-app/main/default/classes/SendMethod.cls
@@ -1,0 +1,1 @@
+global enum SendMethod {SYNC, FUTURE, EVENT}

--- a/force-app/main/default/classes/SendMethod.cls-meta.xml
+++ b/force-app/main/default/classes/SendMethod.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="SendMethod">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/objects/RollbarEvent__e/RollbarEvent__e.object-meta.xml
+++ b/force-app/main/default/objects/RollbarEvent__e/RollbarEvent__e.object-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <eventType>HighVolume</eventType>
+    <label>Rollbar Event</label>
+    <pluralLabel>Rollbar Events</pluralLabel>
+    <publishBehavior>PublishImmediately</publishBehavior>
+</CustomObject>

--- a/force-app/main/default/objects/RollbarEvent__e/fields/Data1__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarEvent__e/fields/Data1__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Data1__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Data1</label>
+    <required>false</required>
+    <type>LongTextArea</type>
+    <length>128000</length>
+    <visibleLines>3</visibleLines>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/tests/DataBuilderTest.cls
+++ b/force-app/main/default/tests/DataBuilderTest.cls
@@ -1,5 +1,5 @@
 @isTest
-public class DataBuilderTest 
+public class DataBuilderTest
 {
     @isTest
     static void testBuildMessagePayload()
@@ -7,10 +7,10 @@ public class DataBuilderTest
         DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
         String expected = 'Message built in DataBuilderTest';
 
-        Map<String, Object> result = subject.buildPayload('info', expected);
+        Map<String, Object> result = subject.buildPayload('info', expected, null);
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
-            
+
         Map<String, Object> notifierMap = (Map<String, Object>)data.get('notifier');
 
         System.assertEquals(Notifier.NAME, (String)notifierMap.get('name'));
@@ -40,7 +40,7 @@ public class DataBuilderTest
             expectedClass = exc.getTypeName();
             throw exc;
         } catch(Exception exc) {
-            Map<String, Object> result = subject.buildPayload(exc);
+            Map<String, Object> result = subject.buildPayload('error', exc, null);
 
             Map<String, Object> data = (Map<String, Object>)result.get('data');
 
@@ -71,7 +71,7 @@ public class DataBuilderTest
 
         DataBuilderTestException exc = new DataBuilderTestException('foobar');
 
-        Map<String, Object> result = subject.buildPayload(exc, expectedCustom);
+        Map<String, Object> result = subject.buildPayload('error', exc, expectedCustom);
         Map<String, Object> data = (Map<String, Object>)result.get('data');
         Map<String, Object> custom = (Map<String, Object>)data.get('custom');
 
@@ -98,7 +98,7 @@ public class DataBuilderTest
         } catch(Exception exc1) {
             expectedClass1 = exc1.getTypeName();
 
-            Map<String, Object> result = subject.buildPayload(exc1);
+            Map<String, Object> result = subject.buildPayload('error', exc1, null);
 
             Map<String, Object> data = (Map<String, Object>)result.get('data');
 
@@ -135,7 +135,7 @@ public class DataBuilderTest
         expected.put('context', 'Exception context');
         expected.put('line', 14);
         expected.put('column', 12);
-        
+
         ExceptionData exData = ExceptionData.fromMap(expected);
 
         Map<String, Object> result = subject.buildPayload(exData);
@@ -145,7 +145,7 @@ public class DataBuilderTest
         Map<String, Object> custom = (Map<String, Object>)data.get('custom');
 
         System.assertEquals((String)expected.get('context'), (String)custom.get('context'));
-            
+
         Map<String, Object> notifierMap = (Map<String, Object>)data.get('notifier');
         System.assertEquals(Notifier.NAME, (String)notifierMap.get('name'));
         System.assertEquals(Notifier.VERSION, (String)notifierMap.get('version'));

--- a/force-app/main/default/tests/NotifierTest.cls
+++ b/force-app/main/default/tests/NotifierTest.cls
@@ -8,14 +8,14 @@ public class NotifierTest {
 
         Notifier subject = new Notifier(config);
 
-        HttpResponse response = subject.log('info', 'Message from the Apex SDK');
+        HttpResponse response = subject.log('info', 'Message from the Apex SDK', null, SendMethod.SYNC);
 
         System.assertEquals(200, response.getStatusCode());
-        
+
         JSONParser parser = JSON.createParser(response.getBody());
         Integer err = null;
         while (parser.nextToken() != null) {
-            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) &&
                 (parser.getText() == 'err')) {
                 parser.nextToken();
                 err = parser.getIntegerValue();
@@ -35,14 +35,14 @@ public class NotifierTest {
 
         DataBuilderTestException exc = new DataBuilderTestException();
 
-        HttpResponse response = subject.log(exc);
+        HttpResponse response = subject.log('error', exc, null, SendMethod.SYNC);
 
         System.assertEquals(200, response.getStatusCode());
-        
+
         JSONParser parser = JSON.createParser(response.getBody());
         Integer err = null;
         while (parser.nextToken() != null) {
-            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) &&
                 (parser.getText() == 'err')) {
                 parser.nextToken();
                 err = parser.getIntegerValue();
@@ -69,17 +69,17 @@ public class NotifierTest {
         expected.put('context', 'Exception context');
         expected.put('line', 14);
         expected.put('column', 12);
-        
+
         ExceptionData exData = ExceptionData.fromMap(expected);
 
-        HttpResponse response = subject.log(exData);
+        HttpResponse response = subject.log(exData, SendMethod.SYNC);
 
         System.assertEquals(200, response.getStatusCode());
-        
+
         JSONParser parser = JSON.createParser(response.getBody());
         Integer err = null;
         while (parser.nextToken() != null) {
-            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) &&
                 (parser.getText() == 'err')) {
                 parser.nextToken();
                 err = parser.getIntegerValue();

--- a/force-app/main/default/tests/RollbarApiVerifyRequestCalloutMock.cls
+++ b/force-app/main/default/tests/RollbarApiVerifyRequestCalloutMock.cls
@@ -1,0 +1,17 @@
+@isTest
+global class RollbarApiVerifyRequestCalloutMock implements HttpCalloutMock {
+    global HTTPResponse respond(HTTPRequest req) {
+        String body = req.getBody();
+        Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(body);
+        Map<String, Object> data = (Map<String, Object>)payload.get('data');
+
+        Map<String, Object> notifierMap = (Map<String, Object>)data.get('notifier');
+        System.assertEquals(Notifier.NAME, (String)notifierMap.get('name'));
+        System.assertEquals(Notifier.VERSION, (String)notifierMap.get('version'));
+
+        HttpResponse response = new HttpResponse();
+        response.setStatusCode(200);
+        response.setBody('{"err":0,"result":{"id":null,"uuid":"e5ea9bee-08e6-41cc-a850-1863980dc224"}}');
+        return response;
+    }
+}

--- a/force-app/main/default/tests/RollbarApiVerifyRequestCalloutMock.cls-meta.xml
+++ b/force-app/main/default/tests/RollbarApiVerifyRequestCalloutMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/tests/RollbarTest.cls
+++ b/force-app/main/default/tests/RollbarTest.cls
@@ -5,9 +5,35 @@ public class RollbarTest {
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
         Rollbar.init('test-token', 'test-env');
-        HttpResponse response = Rollbar.log('info', 'Message from the Apex SDK');
+        HttpResponse response = Rollbar.log('info', 'Message from the Apex SDK', SendMethod.SYNC);
 
         System.assertEquals(200, response.getStatusCode());
+    }
+
+    @isTest
+    public static void testLogMessageFuture() {
+        Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyRequestCalloutMock());
+
+        insert new RollbarSettings__c(AccessToken__c = 'test-token');
+
+        Test.startTest();
+        Rollbar.log('info', 'Message from the Apex SDK', SendMethod.FUTURE);
+        Test.stopTest();
+
+        // Asserts valid payload in the mock.
+    }
+
+    @isTest
+    public static void testLogMessageEvent() {
+        Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyRequestCalloutMock());
+
+        insert new RollbarSettings__c(AccessToken__c = 'test-token');
+
+        Test.startTest();
+        Rollbar.log('info', 'Message from the Apex SDK', SendMethod.EVENT);
+        Test.stopTest();
+
+        // Asserts valid payload in the mock.
     }
 
     @isTest
@@ -15,7 +41,7 @@ public class RollbarTest {
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
         Rollbar.init('test-token', 'test-env');
-        HttpResponse response = Rollbar.log(new DataBuilderTestException());
+        HttpResponse response = Rollbar.log(new DataBuilderTestException(), SendMethod.SYNC);
 
         System.assertEquals(200, response.getStatusCode());
     }

--- a/force-app/main/default/triggers/EventSend.trigger
+++ b/force-app/main/default/triggers/EventSend.trigger
@@ -1,0 +1,7 @@
+trigger EventSend on RollbarEvent__e (after insert) {
+    Notifier notifier = Rollbar.initializedInstance().notifier();
+
+    for (RollbarEvent__e event : Trigger.New) {
+        notifier.methodSend(event.Data1__c, SendMethod.FUTURE);
+    }
+}

--- a/force-app/main/default/triggers/EventSend.trigger-meta.xml
+++ b/force-app/main/default/triggers/EventSend.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -18,6 +18,7 @@
         <members>RollbarInstaller</members>
         <members>EmailServiceInstaller</members>
         <members>RollbarNotInitializedException</members>
+        <members>SendMethod</members>
 
         <!-- tests -->
         <members>ConfigTest</members>
@@ -30,6 +31,7 @@
 
         <!-- test helpers -->
         <members>RollbarApiCalloutMock</members>
+        <members>RollbarApiVerifyRequestCalloutMock</members>
         <members>DataBuilderTestException</members>
     </types>
 
@@ -41,5 +43,11 @@
     <types>
         <name>CustomObject</name>
         <members>RollbarSettings__c</members>
+        <members>RollbarEvent__e</members>
+    </types>
+
+    <types>
+        <name>ApexTrigger</name>
+        <members>EventSend</members>
     </types>
 </Package>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
   ],
   "namespace": "rollbar",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "45.0"
+  "sourceApiVersion": "47.0"
 }


### PR DESCRIPTION
Till now, Rollbar items were always sent on a synchronous callout (HTTP request). This has several limitations:
* Can't call during or after DML.
* Can't call from trigger.
* Sync callout limits apply.

This PR allows items to be sent via Platform Event, Future, or synchronous, with Platform Event being the default. Using Platform Events has numerous advantages:
* Can call at any time during DML, and can send whether or not the DML transaction succeeds.
* Can call from Triggers, Futures, Queuable Jobs, and from other Platform Events.
* Some resource limits apply, but are easier to manage than the sync callout limit.

More detailed information here:
https://rollbar.quip.com/2zxYA0bELPlv/Apex-Rollbar-Callouts

When the user wants to perform the callout synchronously or from a future, this is also supported:
```
Rollbar.log('info', 'hello', SendMethod.SYNC);
Rollbar.log('info', 'hello', SendMethod.FUTURE);
```