### PR TITLE
Flow and Process error reports

### DIFF
--- a/force-app/main/default/classes/DataBuilder.cls
+++ b/force-app/main/default/classes/DataBuilder.cls
@@ -3,9 +3,9 @@ public with sharing class DataBuilder {
         this.config = config;
     }
 
-    public Map<String, Object> buildPayload(String level, String message, Map<String, Object> custom)
+    public Map<String, Object> buildPayload(String level, String message, Map<String, Object> custom, List<Telemetry> telemetry)
     {
-        return buildPayloadStructure(level, buildMessageBody(message), custom);
+        return buildPayloadStructure(level, buildMessageBody(message, telemetry), custom);
     }
 
     public Map<String, Object> buildPayload(String level, Exception exc, Map<String, Object> custom)
@@ -86,13 +86,22 @@ public with sharing class DataBuilder {
         return structure;
     }
 
-    private Map<String, Object> buildMessageBody(String message)
+    private Map<String, Object> buildMessageBody(String message, List<Telemetry> telemetry)
     {
         Map<String, Object> messageMap = new Map<String, Object>();
         messageMap.put('body', message);
 
         Map<String, Object> body = new Map<String, Object>();
         body.put('message', messageMap);
+
+        if (telemetry != null) {
+            List<Object> telemetryList = new List<Object>();
+
+            for (Telemetry t : telemetry) {
+                telemetryList.add(t.toMap());
+            }
+            body.put('telemetry', telemetryList);
+        }
 
         return body;
     }

--- a/force-app/main/default/classes/ExceptionEmailParser.cls
+++ b/force-app/main/default/classes/ExceptionEmailParser.cls
@@ -15,6 +15,12 @@ public with sharing class ExceptionEmailParser {
         return exData;
     }
 
+    private static String fromName = 'ApexApplication';
+
+    public static String fromName() {
+        return fromName;
+    }
+
     public static String parseEnvironment(String emailBody) {
         return emailBody.split('\\n')[0];
     }

--- a/force-app/main/default/classes/FlowEmailParser.cls
+++ b/force-app/main/default/classes/FlowEmailParser.cls
@@ -1,0 +1,77 @@
+public with sharing class FlowEmailParser {
+    public static List<Telemetry> parseTelemetry(String emailBody) {
+        List<String> lines = emailBody.split('\n');
+
+        return parseLines(lines);
+    }
+
+    private static String fromName = 'FlowApplication';
+
+    public static String fromName() {
+        return fromName;
+    }
+
+    // Flow email message blocks are generally multiline and separated by
+    // one or more lines of white space. There are an arbitrary number of blocks
+    // and an arbitrary number of lines within a block.
+    //
+    // This parser converts each block into a 'log' telemetry event.
+    // Telemetry messages don't render line breaks, so we use punctuation to
+    // format the message and improve readability.
+    private static List<Telemetry> parseLines(List<String> lines) {
+        List<Telemetry> telemetryList = new List<Telemetry>();
+        Boolean blank = true;
+        Boolean prevBlank = true;
+
+        // Init these to ensure any initial state below is safe.
+        String messageFirstLine = '';
+        List<String> messageLines = new List<String>();
+
+        for (String line : lines) {
+            String plain = stripHtmlTags(line);
+            blank = String.isBlank(plain);
+
+            // Lightweight state machine using blank, prevBlank.
+            if (prevBlank && blank) {
+                // continue to next block.
+            } else if (prevBlank && !blank) { // start new block
+                // Handle first line separately for better formatting.
+                messageFirstLine = plain + ' ';
+                messageLines = new List<String>();
+            } else if (!prevBlank && !blank) { // continue block
+                messageLines.add(plain);
+            } else { // end block
+                String message = messageFirstLine + String.join(messageLines, ', ');
+                telemetryList.add(addMessage(message));
+            }
+            prevBlank = blank;
+        }
+
+        return telemetryList;
+    }
+
+    private static Telemetry addMessage(String message) {
+        return new Telemetry(
+            'info',
+            'log',
+            'server',
+            Datetime.now().getTime(),
+            new Map<String, String>{ 'message' => message }
+        );
+    }
+
+    // Flow emails are delivered in html format only.
+    // This tag stripper is forgiving of <> characters within the content
+    // as it will only match innermost brackets where additional brackets exist.
+    // (Flow error emails can't be counted on to be valid html in all cases.)
+    //
+    // NB: String.stripHtmlTags() is not used, as it is scheduled for deprecation,
+    // doesn't remove all tags, and its implementation isn't open for review.
+    private static String stripHtmlTags(String html) {
+        String HTML_TAGS = '<[^<>]+>';
+        Pattern pattern = Pattern.compile(HTML_TAGS);
+        Matcher matcher = pattern.matcher(html);
+        return matcher.replaceAll('');
+    }
+
+}

--- a/force-app/main/default/classes/FlowEmailParser.cls-meta.xml
+++ b/force-app/main/default/classes/FlowEmailParser.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="FlowEmailParser">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/Notifier.cls
+++ b/force-app/main/default/classes/Notifier.cls
@@ -9,9 +9,9 @@ public with sharing class Notifier
         this.dataBuilder = new DataBuilder(this.config);
     }
 
-    public HttpResponse log(String level, String message, Map<String, Object> custom, SendMethod method)
+    public HttpResponse log(String level, String message, Map<String, Object> custom, List<Telemetry> telemetry, SendMethod method)
     {
-        return send(dataBuilder.buildPayload(level, message, custom), method);
+        return send(dataBuilder.buildPayload(level, message, custom, telemetry), method);
     }
 
     public HttpResponse log(String level, Exception exc, Map<String, Object> custom, SendMethod method)

--- a/force-app/main/default/classes/Rollbar.cls
+++ b/force-app/main/default/classes/Rollbar.cls
@@ -41,20 +41,26 @@ global with sharing class Rollbar {
     }
 
     global static HttpResponse log(String level, String message) {
-        return log(level, message, null, null);
+        return log(level, message, null, null, null);
     }
 
     global static HttpResponse log(String level, String message, Map<String, Object> custom) {
-        return log(level, message, custom, null);
+        return log(level, message, custom, null, null);
     }
 
     global static HttpResponse log(String level, String message, SendMethod method) {
-        return log(level, message, null, method);
+        return log(level, message, null, null, method);
     }
 
     global static HttpResponse log(String level, String message, Map<String, Object> custom, SendMethod method) {
+        return log(level, message, custom, null, method);
+    }
+
+    // Keep this unpublished (public, not global) until Telemetry interface can be frozen,
+    // which might be never.
+    public static HttpResponse log(String level, String message, Map<String, Object> custom, List<Telemetry> telemetry, SendMethod method) {
         Rollbar instance = initializedInstance();
-        return instance.notifier.log(level, message, custom, method);
+        return instance.notifier.log(level, message, custom, telemetry, method);
     }
 
     global static HttpResponse log(Exception exc) {

--- a/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
+++ b/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
@@ -1,23 +1,15 @@
 global class RollbarExceptionEmailHandler implements Messaging.InboundEmailHandler {
- 
-  global Messaging.InboundEmailResult handleInboundEmail(Messaging.inboundEmail email, 
+
+  global Messaging.InboundEmailResult handleInboundEmail(Messaging.InboundEmail email,
                                                        Messaging.InboundEnvelope env){
- 
-    // Create an InboundEmailResult object for returning the result of the 
+
+    // Create an InboundEmailResult object for returning the result of the
     // Apex Email Service
     Messaging.InboundEmailResult result = new Messaging.InboundEmailResult();
 
-    String emailBody = '';    
-
-    // Add the email plain text into the local variable 
-    emailBody = email.plainTextBody;
-
-    Rollbar.init();
-
     try {
       try {
-        ExceptionData exData = ExceptionEmailParser.parse(emailBody);
-        Rollbar.log(exData);
+        parseAndSend(email);
       } catch(Exception exc) {
         exc.getStackTraceString(); // without those calls strack trace string is not populated
         throw new ExceptionEmailParsingException('Unable to process unhandled exception email', exc);
@@ -26,16 +18,54 @@ global class RollbarExceptionEmailHandler implements Messaging.InboundEmailHandl
       wrapper.getStackTraceString(); // without those calls strack trace string is not populated
 
       Map<String, String> custom = new Map<String, String>();
-      custom.put('email_body', emailBody);
+      custom.put('email_body', getUnknownEmailBody(email));
 
       Rollbar.log(wrapper, custom);
     }
 
-    // Set the result to true. No need to send an email back to the user 
+    // Set the result to true. No need to send an email back to the user
     // with an error message
     result.success = true;
 
     // Return the result for the Apex Email Service
     return result;
   }
+
+    private void parseAndSend(Messaging.InboundEmail email) {
+        String emailBody = '';
+
+        Rollbar.init();
+
+        // The fromName field is the most reliable known way to differentiate
+        // Exception and Flow email types.
+        if (email.fromName == ExceptionEmailParser.fromName()) {
+            emailBody = email.plainTextBody;
+            ExceptionData exData = ExceptionEmailParser.parse(emailBody);
+
+            Rollbar.log(exData);
+        } else if (email.fromName == FlowEmailParser.fromName()) {
+            emailBody = email.htmlBody;
+            List<Telemetry> telemetry = FlowEmailParser.parseTelemetry(emailBody);
+
+            Rollbar.log('error', email.subject, null, telemetry, SendMethod.SYNC);
+        } else {
+            // Unknown email type.
+            // TODO: Use emailBody and fromName in notifier.diagnostic
+
+            Rollbar.log('error', email.subject, null, null, SendMethod.SYNC);
+        }
+    }
+
+    // Salesforce emails may contain either plain or html parts, but in the
+    // case of Exception and Flow emails, they don't contain both.
+    // This helper prefers plain, but will return html is it's the only part found.
+    private String getUnknownEmailBody(Messaging.InboundEmail email) {
+        String emailBody = email.plainTextBody;
+
+        // Use html Body if no plain body is found.
+        if (emailBody == null || emailBody == '') {
+            emailBody = email.htmlBody;
+        }
+        return emailBody;
+    }
 }

--- a/force-app/main/default/classes/Telemetry.cls
+++ b/force-app/main/default/classes/Telemetry.cls
@@ -1,0 +1,44 @@
+public with sharing class Telemetry {
+    public String level { get; set; }
+    public String type { get; set; }
+    public String source { get; set; }
+    public Long timestamp { get; set; }
+    public Map<String, String> body { get; set; }
+
+    public Telemetry(
+        String level,
+        String type,
+        String source,
+        Long timestamp,
+        Map<String, String> body
+    ) {
+        this.level = level;
+        this.type = type;
+        this.source = source;
+        this.timestamp = timestamp;
+        this.body = body;
+    }
+    public Telemetry() {}
+
+    public static Telemetry fromMap(Map<String, Object> inMap) {
+        return new Telemetry(
+            (String)inMap.get('level'),
+            (String)inMap.get('type'),
+            (String)inMap.get('source'),
+            (Long)inMap.get('timestamp_ms'),
+            (Map<String, String>)inMap.get('body')
+        );
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> outMap = new Map<String, Object>();
+
+        outMap.put('level', this.level);
+        outMap.put('type', this.type);
+        outMap.put('source', this.source);
+        outMap.put('timestamp_ms', this.timestamp);
+        outMap.put('body', this.body);
+
+        return outMap;
+    }
+}

--- a/force-app/main/default/classes/Telemetry.cls-meta.xml
+++ b/force-app/main/default/classes/Telemetry.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="Telemetry">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/tests/DataBuilderTest.cls
+++ b/force-app/main/default/tests/DataBuilderTest.cls
@@ -7,7 +7,7 @@ public class DataBuilderTest
         DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
         String expected = 'Message built in DataBuilderTest';
 
-        Map<String, Object> result = subject.buildPayload('info', expected, null);
+        Map<String, Object> result = subject.buildPayload('info', expected, null, null);
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
 
@@ -19,6 +19,49 @@ public class DataBuilderTest
         Map<String, Object> body = (Map<String, Object>)data.get('body');
 
         System.assertEquals(expected, ((Map<String, Object>)body.get('message')).get('body'));
+    }
+
+    @isTest
+    static void testBuildMessagePayloadWithTelemetry()
+    {
+        DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
+
+        List<Telemetry> telemetryList = new List<Telemetry>();
+        telemetryList.add(new Telemetry(
+            'info',
+            'log',
+            'server',
+            987654321,
+            new Map<String, String>{ 'message' => 'first' }
+        ));
+        telemetryList.add(new Telemetry(
+            'info',
+            'log',
+            'server',
+            987654321,
+            new Map<String, String>{ 'message' => 'second' }
+        ));
+
+        Map<String, Object> result = subject.buildPayload('info', 'Telemetry test', null, telemetryList);
+
+        Map<String, Object> data = (Map<String, Object>)result.get('data');
+        Map<String, Object> body = (Map<String, Object>)data.get('body');
+
+        List<Map<String, Object>> telemetryObjects = new List<Map<String, Object>>();
+        for (Object instance : (List<Object>)body.get('telemetry')) {
+            telemetryObjects.add((Map<String, Object>)instance);
+        }
+
+        for (Map<String, Object> telemetry : telemetryObjects) {
+            System.assertEquals((String)telemetry.get('level'), 'info');
+            System.assertEquals((String)telemetry.get('type'), 'log');
+            System.assertEquals((String)telemetry.get('source'), 'server');
+            System.assertEquals((Long)telemetry.get('timestamp_ms'), 987654321);
+        }
+        Map<String, String> messageBody = (Map<String, String>)telemetryObjects.get(0).get('body');
+        System.assertEquals(messageBody.get('message'), 'first');
+        messageBody = (Map<String, String>)telemetryObjects.get(1).get('body');
+        System.assertEquals(messageBody.get('message'), 'second');
     }
 
     @isTest

--- a/force-app/main/default/tests/FlowEmailParserTest.cls
+++ b/force-app/main/default/tests/FlowEmailParserTest.cls
@@ -1,0 +1,58 @@
+@isTest
+public class FlowEmailParserTest {
+    private static String emailBody =
+        '<!DOCTYPE html><html><p>\n' +
+        'Error element myRule_1_A1 (FlowRecordUpdate).<br>\n' +
+        'The flow tried to update these records: null.\n' +
+        'You can look up ExceptionCode values in the\n' +
+        '<a href=3D\'https://developer.salesforce.com/docs/\'>SOAP API Developer Guide</a>.<br>\n' +
+        '</p>\n' +
+        '<hr>\n' +
+        '<p>\n' +
+        '<span style=3D"font-weight:bold">Flow Details > </span><br>\n' +
+        'Flow API Name: Contact_address_change_V2<br>\n' +
+        'Type: Record < Change Process<br>\n' +
+        'Version: <> 1<br>\n' +
+        'Status: Active<br>\n' +
+        'Org: Example Org (00D6g00000756dd)<br>\n' +
+        '</p>\n' +
+        '<p>\n' +
+        '<span style=3D"font-weight:bold">Flow Interview Details</span><br>\n' +
+        'Interview Label: Contact_address_change_V2-1_InterviewLabel<br>\n' +
+        'Current User: Example User (0056g0000067Oja)<br>\n' +
+        'Start time: 5/21/2020, 12:20 PM<br>\n' +
+        'Duration: 0 seconds<br>\n' +
+        '</p>\n' +
+        '<p>\n' +
+        '<span style=3D"font-weight:bold">How the Interview Started</span><br>\n' +
+        'Example User (0056g0000067Oja) started the flow interview.<br>\n' +
+        'Some of this flow\'s variables were set when the interview started.<br>\n' +
+        'myVariable_old =3D Account (0015g00000NicIeBBJ)<br>\n' +
+        'myVariable_current =3D Account (0015g00000NicIeBBJ)<br>\n' +
+        '</p></body></html>\n';
+        //     ^ Ends with a dangling "</body> because that's what the actual email body does.
+
+    @isTest
+    public static void testParse() {
+        List<Telemetry> telemetryList = FlowEmailParser.parseTelemetry(emailBody);
+
+        System.assertEquals(telemetryList.size(), 4);
+
+        for (Telemetry telemetry : telemetryList) {
+            System.assertEquals(telemetry.level, 'info');
+            System.assertEquals(telemetry.type, 'log');
+            System.assertEquals(telemetry.source, 'server');
+
+            String message = telemetry.body.get('message');
+            System.assertEquals(message.split('\n').size(), 1);
+        }
+        System.assert(telemetryList.get(0).body.get('message').startsWith('Error element'));
+        System.assert(telemetryList.get(1).body.get('message').startsWith('Flow Details'));
+        System.assert(telemetryList.get(2).body.get('message').startsWith('Flow Interview Details'));
+        System.assert(telemetryList.get(3).body.get('message').startsWith('How the Interview Started'));
+
+        // Confirm handling of unexpected <>
+        System.assert(telemetryList.get(1).body.get('message').contains('Change Process'));
+        System.assert(telemetryList.get(1).body.get('message').contains('<>'));
+    }
+}

--- a/force-app/main/default/tests/FlowEmailParserTest.cls-meta.xml
+++ b/force-app/main/default/tests/FlowEmailParserTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="FlowEmailParserTest">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/tests/NotifierTest.cls
+++ b/force-app/main/default/tests/NotifierTest.cls
@@ -8,7 +8,7 @@ public class NotifierTest {
 
         Notifier subject = new Notifier(config);
 
-        HttpResponse response = subject.log('info', 'Message from the Apex SDK', null, SendMethod.SYNC);
+        HttpResponse response = subject.log('info', 'Message from the Apex SDK', null, null, SendMethod.SYNC);
 
         System.assertEquals(200, response.getStatusCode());
 

--- a/force-app/main/default/tests/RollbarApiVerifyTelemetryCalloutMock.cls
+++ b/force-app/main/default/tests/RollbarApiVerifyTelemetryCalloutMock.cls
@@ -1,0 +1,17 @@
+@isTest
+global class RollbarApiVerifyTelemetryCalloutMock implements HttpCalloutMock {
+    global HTTPResponse respond(HTTPRequest req) {
+        String body = req.getBody();
+        Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(body);
+        Map<String, Object> data = (Map<String, Object>)payload.get('data');
+        Map<String, Object> messageBody = (Map<String, Object>)data.get('body');
+        List<Map<String, Object>> telemetry = (List<Map<String, Object>>)messageBody.get('telemetry');
+
+        System.assert(telemetry.size() > 0);
+
+        HttpResponse response = new HttpResponse();
+        response.setStatusCode(200);
+        response.setBody('{"err":0,"result":{"id":null,"uuid":"e5ea9bee-08e6-41cc-a850-1863980dc224"}}');
+        return response;
+    }
+}

--- a/force-app/main/default/tests/RollbarApiVerifyTelemetryCalloutMock.cls-meta.xml
+++ b/force-app/main/default/tests/RollbarApiVerifyTelemetryCalloutMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls
+++ b/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls
@@ -1,0 +1,20 @@
+@isTest
+private class RollbarExceptionEmailHandlerTest {
+
+    @isTest
+    public static void testFlowEmail() {
+        Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyTelemetryCalloutMock());
+
+        Messaging.InboundEnvelope envelope = new Messaging.InboundEnvelope();
+        Messaging.InboundEmail email = new Messaging.InboundEmail();
+        email.fromName = 'FlowApplication';
+        email.htmlBody = '<html>Test Flow message</html>\n\n';
+
+        Rollbar.init('test-token', 'test-env');
+
+        RollbarExceptionEmailHandler handler = new RollbarExceptionEmailHandler();
+        handler.handleInboundEmail(email, envelope);
+
+        // Asserts valid payload in the mock.
+    }
+}

--- a/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls-meta.xml
+++ b/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="RollbarExceptionEmailHandlerTest">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/tests/RollbarTest.cls
+++ b/force-app/main/default/tests/RollbarTest.cls
@@ -37,6 +37,25 @@ public class RollbarTest {
     }
 
     @isTest
+    public static void testLogMessageWithCustomDataAndTelemetry() {
+        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+
+        Map<String, Object> customData = new Map<String, Object>{ 'foo' => 'bar' };
+        List<Telemetry> telemetryList = new List<Telemetry>();
+
+        Rollbar.init('test-token', 'test-env');
+        HttpResponse response = Rollbar.log(
+            'info',
+            'Message from the Apex SDK',
+            customData,
+            telemetryList,
+            SendMethod.SYNC
+        );
+
+        System.assertEquals(200, response.getStatusCode());
+    }
+
+    @isTest
     public static void testLogException() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 

--- a/force-app/main/default/tests/TelemetryTest.cls
+++ b/force-app/main/default/tests/TelemetryTest.cls
@@ -1,0 +1,40 @@
+@isTest
+private class TelemetryTest {
+
+    @isTest
+    public static void testConstructor() {
+        Telemetry telemetry =  new Telemetry(
+            'info',
+            'log',
+            'server',
+            987654321,
+            new Map<String, String>{ 'foo' => 'bar' }
+        );
+        System.assertEquals(telemetry.level, 'info');
+        System.assertEquals(telemetry.type, 'log');
+        System.assertEquals(telemetry.source, 'server');
+        System.assertEquals(telemetry.timestamp, 987654321);
+        System.assertEquals(telemetry.body.get('foo'), 'bar');
+    }
+
+    @isTest
+    public static void testMap() {
+        Map<String, Object> inMap = new Map<String, Object>();
+        inMap.put('level', 'info');
+        inMap.put('type', 'log');
+        inMap.put('source', 'server');
+        inMap.put('timestamp_ms', 987654321);
+        inMap.put('body', new Map<String, String>{ 'foo' => 'bar' });
+
+        Telemetry telemetry = Telemetry.fromMap(inMap);
+
+        Map<String, Object> outMap = telemetry.toMap();
+
+        System.assertEquals(outMap.get('level'), 'info');
+        System.assertEquals(outMap.get('type'), 'log');
+        System.assertEquals(outMap.get('source'), 'server');
+        System.assertEquals(outMap.get('timestamp_ms'), 987654321);
+        Map<String, String> body = (Map<String, String>) outMap.get('body');
+        System.assertEquals(body.get('foo'), 'bar');
+    }
+}

--- a/force-app/main/default/tests/TelemetryTest.cls-meta.xml
+++ b/force-app/main/default/tests/TelemetryTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="TelemetryTest">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -10,6 +10,7 @@
         <members>ExceptionData</members>
         <members>ExceptionEmailParser</members>
         <members>ExceptionEmailParsingException</members>
+        <members>FlowEmailParser</members>
         <members>MetadataService</members>
         <members>Notifier</members>
         <members>Rollbar</members>
@@ -19,19 +20,24 @@
         <members>EmailServiceInstaller</members>
         <members>RollbarNotInitializedException</members>
         <members>SendMethod</members>
+        <members>Telemetry</members>
 
         <!-- tests -->
         <members>ConfigTest</members>
         <members>DataBuilderTest</members>
         <members>ExceptionEmailParserTest</members>
+        <members>FlowEmailParserTest</members>
         <members>NotifierTest</members>
         <members>MetadataServiceTest</members>
         <members>RollbarConfigureControllerTest</members>
+        <members>RollbarExceptionEmailHandlerTest</members>
         <members>RollbarTest</members>
+        <members>TelemetryTest</members>
 
         <!-- test helpers -->
         <members>RollbarApiCalloutMock</members>
         <members>RollbarApiVerifyRequestCalloutMock</members>
+        <members>RollbarApiVerifyTelemetryCalloutMock</members>
         <members>DataBuilderTestException</members>
     </types>
 


### PR DESCRIPTION
Salesforce reports errors in Flows and Processes by sending error emails. These are routed to the same email handler as Apex Exception reports, however the format is very different.

We use the `fromName` property to detect which email type is being handled, and route to the correct parser class.

Flow and Process emails do not contain stack traces or a code-level error location. Rather they contain a list of log entries of the user actions leading up to the error, as well as metadata about the state of the Flow at the time of the error. This fits well with the way telemetry is used in Rollbar occurrences, and so these are converted to a list of telemetry events in the payload, with type='log'.

The log entries in the email body are generally unstructured text. There are always one or more lines of whitespace between each, so these newlines are the marker used to separate each message into a separate telemetry event.

While the Exception emails use only the plain text part of the email body, the Flow/Process emails use only the html part. On inspection, the html is not reliably valid, however tag stripping can be performed reliably. The body is tag stripped, and then treated as plain text.

The email title contains the description of the error itself, and this is used as the error message in the occurrence.