### PR TITLE
Enable package uninstall

### DIFF
--- a/force-app/main/default/classes/EmailServiceInstaller.cls
+++ b/force-app/main/default/classes/EmailServiceInstaller.cls
@@ -88,4 +88,66 @@ public with sharing class EmailServiceInstaller {
         Http h = new Http();
         HttpResponse res = h.send(req);
     }
+
+    public static void deleteEmailServiceFunction(EmailServicesFunction emailServiceFunction)
+    {
+        String baseUrl = URL.getOrgDomainUrl().toExternalForm() + '/services/Soap/u/48.0';
+
+        HTTPRequest req = new HTTPRequest();
+        req.setEndpoint(baseUrl);
+        req.setMethod('POST');
+        req.setHeader('SOAPAction', '""');
+        req.setHeader('Content-Type', 'text/xml');
+        req.setBody(
+            '<?xml version="1.0" encoding="utf-8"?>' +
+              '<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:partner.soap.sforce.com">' +
+                '<env:Header>' +
+                    '<urn:SessionHeader>' +
+                        '<urn:sessionId>'+UserInfo.getSessionId()+'</urn:sessionId>' +
+                    '</urn:SessionHeader>' +
+                '</env:Header>' +
+                '<env:Body>' +
+                    '<urn:delete>' +
+                        '<urn:ids>' +
+                            emailServiceFunction.Id +
+                        '</urn:ids>' +
+                    '</urn:delete>' +
+                '</env:Body>' +
+            '</env:Envelope>'
+        );
+
+        Http h = new Http();
+        HttpResponse res = h.send(req);
+    }
+
+    public static void deleteEmailServiceAddress(EmailServicesAddress emailServiceAddress)
+    {
+        String baseUrl = URL.getOrgDomainUrl().toExternalForm() + '/services/Soap/u/48.0';
+
+        HTTPRequest req = new HTTPRequest();
+        req.setEndpoint(baseUrl);
+        req.setMethod('POST');
+        req.setHeader('SOAPAction', '""');
+        req.setHeader('Content-Type', 'text/xml');
+        req.setBody(
+            '<?xml version="1.0" encoding="utf-8"?>' +
+              '<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:partner.soap.sforce.com">' +
+                '<env:Header>' +
+                    '<urn:SessionHeader>' +
+                        '<urn:sessionId>'+UserInfo.getSessionId()+'</urn:sessionId>' +
+                    '</urn:SessionHeader>' +
+                '</env:Header>' +
+                '<env:Body>' +
+                    '<urn:delete>' +
+                        '<urn:ids>' +
+                            emailServiceAddress.Id +
+                        '</urn:ids>' +
+                    '</urn:delete>' +
+                '</env:Body>' +
+            '</env:Envelope>'
+        );
+
+        Http h = new Http();
+        HttpResponse res = h.send(req);
+    }
 }

--- a/force-app/main/default/classes/RollbarConfigureController.cls
+++ b/force-app/main/default/classes/RollbarConfigureController.cls
@@ -53,8 +53,27 @@ public with sharing class RollbarConfigureController {
         return null;
     }
 
+    public Pagereference uninstall() {
+        RollbarInstaller.prepareUninstall();
+
+        this.settings = RollbarSettings__c.getOrgDefaults();
+        this.settings.PreparedForUninstall__c = true;
+        upsert this.settings;
+        updateConfigState();
+        return null;
+    }
+
+    public Pagereference reinstall() {
+        this.settings.PreparedForUninstall__c = false;
+        upsert this.settings;
+        updateConfigState();
+        return null;
+    }
+
     public void updateConfigState() {
-        if (!this.settings.Initialized__c) {
+        if (this.settings.PreparedForUninstall__c) {
+            this.configState = 'ConfigState.UNINSTALL';
+        } else if (!this.settings.Initialized__c) {
             this.configState = 'ConfigState.INIT';
         } else if (!this.settings.SalesforceApiEnabled__c) {
             this.configState = 'ConfigState.SF_API';

--- a/force-app/main/default/classes/RollbarInstaller.cls
+++ b/force-app/main/default/classes/RollbarInstaller.cls
@@ -5,6 +5,22 @@ public with sharing class RollbarInstaller {
         return RollbarInstaller.enableServices(config.endpoint());
     }
 
+    @future(callout=true)
+    public static void prepareUninstall()
+    {
+        RollbarSettings__c settings = RollbarSettings__c.getOrgDefaults();
+
+        deleteApexEmailNotification();
+        deleteEmailServicesFunction();
+        deleteRemoteSiteSetting();
+
+        settings.RollbarApiEnabled__c = remoteSiteSettingSetUp();
+        settings.EmailServiceEnabled__c = rollbarEmailServiceSetUp();
+        settings.NotificationForwardingEnabled__c = apexNotificationsForwardingSetUp();
+
+        upsert settings;
+    }
+
     public static String enableServices(String apiDomain)
     {
         String message = null;
@@ -103,16 +119,11 @@ public with sharing class RollbarInstaller {
 
     public static Boolean rollbarApiEndpointAllowed(String endpoint)
     {
-        MetadataService.MetadataPort service = MetadataService.createServiceWithSession();
-        MetadataService.ReadRemoteSiteSettingResult result = (MetadataService.ReadRemoteSiteSettingResult)service.readMetadata('RemoteSiteSetting', new String[] {'RollbarAPI'});
+        MetadataService.RemoteSiteSetting setting = remoteSiteSetting();
 
-        MetadataService.Metadata[] records = result.getRecords();
-
-        if (records.size() == 0) {
+        if (setting == null) {
             return false;
         }
-
-        MetadataService.RemoteSiteSetting setting = (MetadataService.RemoteSiteSetting)result.getRecords()[0];
 
         if (setting.fullName != 'RollbarAPI') {
             return false;
@@ -123,6 +134,40 @@ public with sharing class RollbarInstaller {
         }
 
         return true;
+    }
+
+    public static MetadataService.RemoteSiteSetting remoteSiteSetting() {
+        MetadataService.MetadataPort service = MetadataService.createServiceWithSession();
+        MetadataService.ReadRemoteSiteSettingResult result = (MetadataService.ReadRemoteSiteSettingResult)service.readMetadata('RemoteSiteSetting', new String[] {'RollbarAPI'});
+
+        MetadataService.Metadata[] records = result.getRecords();
+
+        if (records.size() == 0) {
+            return null;
+        }
+
+        MetadataService.RemoteSiteSetting setting = (MetadataService.RemoteSiteSetting)result.getRecords()[0];
+
+        if (setting.fullName == 'RollbarAPI') {
+            return setting;
+        } else {
+            return null;
+        }
+    }
+
+    public static Boolean remoteSiteSettingSetUp() {
+        if (remoteSiteSetting() != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public static void deleteRemoteSiteSetting() {
+        if (RollbarInstaller.remoteSiteSetting() != null) {
+            MetadataService.MetadataPort service = MetadataService.createServiceWithSession();
+            service.deleteMetadata('RemoteSiteSetting', new String[] {'RollbarAPI'});
+        }
     }
 
     public static Boolean rollbarPingSuccessful()
@@ -140,8 +185,8 @@ public with sharing class RollbarInstaller {
     public static Boolean rollbarEmailServiceSetUp()
     {
         try {
-            EmailServicesFunction emailFunction = [SELECT Id FROM EmailServicesFunction WHERE FunctionName='RollbarEmailService'];
-            EmailServicesAddress emailServicesAddress = [SELECT Id, LocalPart, EmailDomainName FROM EmailServicesAddress WHERE FunctionId = :emailFunction.Id];
+            EmailServicesFunction emailFunction = emailServicesFunction();
+            EmailServicesAddress emailServicesAddress = emailServicesAddress(emailFunction);
         } catch (Exception ex) {
             return false;
         }
@@ -149,28 +194,79 @@ public with sharing class RollbarInstaller {
         return true;
     }
 
-    public static Boolean apexNotificationsForwardingSetUp()
-    {
+    public static EmailServicesFunction emailServicesFunction() {
+        return [SELECT Id FROM EmailServicesFunction WHERE FunctionName='RollbarEmailService'];
+    }
+
+    public static EmailServicesAddress emailServicesAddress(EmailServicesFunction emailFunction) {
+        return [SELECT Id, LocalPart, EmailDomainName FROM EmailServicesAddress WHERE FunctionId = :emailFunction.Id];
+    }
+
+    public static ApexEmailNotification apexEmailNotification() {
         EmailServicesFunction emailFunction;
         EmailServicesAddress emailServicesAddress;
         try {
-            emailFunction = [SELECT Id FROM EmailServicesFunction WHERE FunctionName='RollbarEmailService'];
-            emailServicesAddress = [SELECT Id, LocalPart, EmailDomainName FROM EmailServicesAddress WHERE FunctionId = :emailFunction.Id];
+            emailFunction = emailServicesFunction();
+            emailServicesAddress = emailServicesAddress(emailFunction);
         } catch (Exception ex) {
-            return false;
+            return null;
         }
 
         String emailServiceAddress = emailServicesAddress.LocalPart + '@' + emailServicesAddress.EmailDomainName;
 
-        Boolean forwarding = false;
         ApexEmailNotification[] apexNotifications = [SELECT Email, UserId FROM ApexEmailNotification];
         for (ApexEmailNotification notification : apexNotifications) {
             if (notification.Email == emailServiceAddress) {
-                forwarding = true;
+                return notification;
             }
         }
 
-        return forwarding;
+        return null; // Not found
+    }
+
+    public static Boolean apexNotificationsForwardingSetUp()
+    {
+        ApexEmailNotification notification = apexEmailNotification();
+
+        if (notification != null) {
+            return true;
+        }
+        return false;
+    }
+
+    public static void deleteApexEmailNotification() {
+        ApexEmailNotification notification = ApexEmailNotification();
+
+        if (notification != null) {
+            String baseUrl = URL.getSalesforceBaseUrl().toExternalForm() + '/services/data/v35.0/tooling/';
+
+            HTTPRequest req = new HTTPRequest();
+            req.setEndpoint(baseUrl + 'sobjects/ApexEmailNotification/' + notification.Id + '/');
+            req.setMethod('DELETE');
+            req.setHeader('Authorization', 'Bearer ' + UserInfo.getSessionId());
+            req.setHeader('Content-Type', 'application/json');
+
+            Http h = new Http();
+            HttpResponse res = h.send(req);
+        }
+    }
+
+    public static void deleteEmailServicesFunction() {
+        EmailServicesFunction emailServicesFunction = EmailServicesFunction();
+
+        if (emailServicesFunction != null) {
+            deleteEmailServicesAddress(emailServicesFunction);
+
+            EmailServiceInstaller.deleteEmailServiceFunction(emailServicesFunction);
+        }
+    }
+
+    public static void deleteEmailServicesAddress(EmailServicesFunction emailServicesFunction) {
+        EmailServicesAddress emailServicesAddress = EmailServicesAddress(emailServicesFunction);
+
+        if (emailServicesAddress != null) {
+            EmailServiceInstaller.deleteEmailServiceAddress(emailServicesAddress);
+        }
     }
 
     public static Boolean accessTokenCorrect(Config config)

--- a/force-app/main/default/objects/RollbarSettings__c/fields/PreparedForUninstall__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/PreparedForUninstall__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>PreparedForUninstall__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Prepared For Uninstall</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/pages/RollbarConfigure.page
+++ b/force-app/main/default/pages/RollbarConfigure.page
@@ -17,8 +17,9 @@
             font-size: 16px;
         }
 
-        section, .next-step {
+        section, .section, .next-step {
             margin-top: 2em;
+            margin-bottom: 2em;
         }
 
         .next-step {
@@ -85,6 +86,23 @@
         <apex:pageBlock id="setup">
             <apex:pageMessages id="errors" />
 
+            <section>
+                <apex:outputPanel rendered="{!configState == 'ConfigState.UNINSTALL'}" layout="block">
+                    <p>
+                        The Rollbar package has been prepared for uninstall by removing
+                        dependencies that must be removed before proceeding with uninstall.
+                        To complete uninstall, navigate to Installed Packages and find the
+                        Uninstall button.
+                    </p>
+                    <p>
+                        If you want to keep the package installed, click to restore the
+                        removed components.
+                    </p>
+                    <apex:form>
+                        <apex:commandButton action="{!reinstall}" value="Restore Install" reRender="setup" />
+                    </apex:form>
+                </apex:outputPanel>
+            </section>
             <section>
                 <apex:outputPanel rendered="{!configState == 'ConfigState.INIT'}" layout="block">
                     The Rollbar package needs to complete a few additional steps
@@ -174,47 +192,18 @@
                     </header>
                     <div class="section">
                         <h4>
-                            Here is how to get started using Rollbar in your Apex code:
+                            For documentation on how to get started using Rollbar in your Salesforce organization, see the
+                            <apex:outputlink value="https://docs.rollbar.com/docs/salesforce-apex" target="_blank">
+                                Rollbar SDK documentation
+                            </apex:outputlink>.
                         </h4>
-                        <div class="section">
-                            <h5>Initialization</h5>
-                            <p>
-                                Default initialization happens implicitly, and there is no
-                                need to exlicitly init unless setting a custom configuration.
-                                The default initialization uses the settings provided in
-                                the package configuration.
-                            </p>
-                            <p>
-                                <code>Rollbar.init();</code>
-                            </p>
-                            <p>
-                                This call will initialize the Rollbar notifier with your organization's
-                                default access token and environment. This is identical to the implicit
-                                initialization.
-                            </p>
-                            <p>
-                                <code>Rollbar.init(String accessToken, String environment);</code>
-                            </p>
-                            <p>
-                                With this overload you can provide a custom access token and custom environment for further
-                                reporting.
-                            </p>
-                        </div>
-                        <div class="section">
-                            <h5>Reporting</h5>
-                            <p>
-                                <code>rollbar.Rollbar.log(String level, String message);</code>
-                            </p>
-                            <p>
-                                This call will report an arbitrary message at one of the Rollbar reporting levels.
-                            </p>
-                            <p>
-                                <code>rollbar.Rollbar.log(Exception exception);</code>
-                            </p>
-                            <p>
-                                You can report an exception object with it's stack trace using the above call.
-                            </p>
-                        </div>
+
+                    </div>
+                </apex:outputPanel>
+            </section>
+            <section>
+                <apex:outputPanel rendered="{!configState == 'ConfigState.COMPLETE'}" layout="block">
+                    <div class="section">
                         <div class="section">
                             <h4>Update Rollbar Token</h4>
                             <apex:form>
@@ -223,6 +212,20 @@
                                 </p>
                                 <div class="next-step">
                                     <apex:commandButton action="{!save}" value="Update and Verify" id="rollbarConfigure" reRender="setup" />
+                                </div>
+                            </apex:form>
+                        </div>
+                        <div class="section">
+                            <h4>Prepare Uninstall</h4>
+                            <p>
+                                When uninstalling the package for any reason, some dependencies
+                                must be removed first. Initiating this action will remove the Email Service,
+                                exception forwarding address, and Remote Site Setting used for the
+                                Rollbar API.
+                            </p>
+                            <apex:form>
+                                <div class="next-step">
+                                    <apex:commandButton action="{!uninstall}" value="Prepare Uninstall" id="rollbarConfigure" reRender="setup" />
                                 </div>
                             </apex:form>
                         </div>


### PR DESCRIPTION
Enables package uninstall by removing dependencies that were added at install time. Salesforce won't allow uninstall before removing these dependencies, and won't remove them automatically.

**Does not use the uninstall hook**
Salesforce's uninstall hook doesn't run before its dependency checks, so can't be used for this purpose. Also, all callouts are prohibited in uninstall hooks, and as described below, removing each of the dependencies requires using callouts.

**Requires the user to click "Prepare Uninstall" in the configuration page**
Since the uninstall hook can't be used, the user must initiate the action prior to package uninstall. Once completed, the config page also provides an option to reinstall the dependencies, so even if clicked by accident, it's easy to get back to a working state.

**Details**
Some package dependencies, like the RollbarSettings object, can be added in the package.xml and are automatically removed on package uninstall. There are three dependencies that cannot be added in the package.xml and are added dynamically:
* Email Service (Added via the Partner SOAP API)
* Exception Email Address (Added via the REST API)
* Remote Site Setting (Added via the Metadata API)

This PR allows removing each of these via their respective APIs.

**Testing**
The main factors in testing this feature are ensuring the dependencies are removed successfully, and ensuring the logic follows Salesforce's requirements around having callouts (HTTP requests) and DML in the same transaction. If the Salesforce framework thinks it detects a violation, the entire transaction is rolled back and an error is raised. Much of the effort in this PR, and in testing the feature, involved making sure this will reliably succeed, as all of the above mentioned APIs must use callouts.

I hoped this PR could make a good opportunity to add test automation for RollbarInstaller, but callouts of any kind are prohibited in Apex tests, and so all callouts must be mocked. In this case, the most necessary testing involves the behavior of the callouts, and critically, any callout violations raised by the Salesforce framework. Testing with mocks has some value, but cannot substitute for the manual testing that is still necessary here.

The mocks themselves must generate valid responses, and DML mocks are also required, so that code paths that read the state of these dependencies also work during testing. So this means mocking three separate and different APIs (Partner SOAP API, REST API, Metadata API) and mocking DML objects for each of the dependencies. This may be worth doing in the future, but is a large enough chunk of work that it should be estimated and prioritized separately.
