### PR TITLE
Always read org defaults from rollbar settings

### DIFF
--- a/force-app/main/default/classes/Rollbar.cls
+++ b/force-app/main/default/classes/Rollbar.cls
@@ -23,7 +23,7 @@ global with sharing class Rollbar {
     public static Rollbar init()
     {
         return Rollbar.init(
-            RollbarSettings__c.getInstance().AccessToken__c,
+            RollbarSettings__c.getOrgDefaults().AccessToken__c,
             UserInfo.getOrganizationName()
         );
     }


### PR DESCRIPTION
`getInstance()` will return values (if any) for the current user or profile added to the settings object. This may often be blank or invalid, and unintentionally present.

Other locations in the package always get/set from the base object at `getOrgDefaults()`, which is the correct method for this use case.