### PR TITLE
Don't add custom key if it's null

### DIFF
--- a/force-app/main/default/classes/DataBuilder.cls
+++ b/force-app/main/default/classes/DataBuilder.cls
@@ -81,7 +81,10 @@ public with sharing class DataBuilder {
         structure.put('environment', environment);
         structure.put('framework', 'apex');
         structure.put('body', body);
-        structure.put('custom', custom);
+
+        if (custom != null) {
+            structure.put('custom', custom);
+        }
 
         return structure;
     }

--- a/force-app/main/default/tests/DataBuilderTest.cls
+++ b/force-app/main/default/tests/DataBuilderTest.cls
@@ -11,6 +11,8 @@ public class DataBuilderTest
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
 
+        System.assertEquals(data.containsKey('custom'), false);
+
         Map<String, Object> notifierMap = (Map<String, Object>)data.get('notifier');
 
         System.assertEquals(Notifier.NAME, (String)notifierMap.get('name'));
@@ -86,6 +88,8 @@ public class DataBuilderTest
             Map<String, Object> result = subject.buildPayload('error', exc, null);
 
             Map<String, Object> data = (Map<String, Object>)result.get('data');
+
+            System.assertEquals(data.containsKey('custom'), false);
 
             Map<String, Object> notifierMap = (Map<String, Object>)data.get('notifier');
             System.assertEquals(Notifier.NAME, (String)notifierMap.get('name'));


### PR DESCRIPTION
When a custom key is present, the item UI prioritizes showing the custom data. Including the `custom` key when it's null causes the null data to be prioritized in the UI.

Basically this keeps the dashboard from needlessly displaying `custom: null` in the item view.