### PR TITLE
Basic config options: Environment and enable/disable options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .sfdx/
 .vscode/
+deploy/

--- a/force-app/main/default/classes/Config.cls
+++ b/force-app/main/default/classes/Config.cls
@@ -4,7 +4,12 @@ public with sharing class Config {
             throw new RollbarNotInitializedException();
         }
         this.accessToken = accessToken;
-        this.environment = environment;
+
+        if (environment == null || environment == '') {
+            this.environment = UserInfo.getOrganizationName();
+        } else {
+            this.environment = environment;
+        }
     }
 
     public Config() {

--- a/force-app/main/default/classes/DataBuilder.cls
+++ b/force-app/main/default/classes/DataBuilder.cls
@@ -131,11 +131,22 @@ public with sharing class DataBuilder {
 
     private Map<String, Object> buildTraceBody(Exception exc)
     {
+        String stackTraceString = exc.getStackTraceString();
+        String typeName = exc.getTypeName();
+        String message = exc.getMessage();
+
+        return buildTraceBody(stackTraceString, typeName, message);
+
+    }
+
+    @testVisible
+    private Map<String, Object> buildTraceBody(String stackTraceString, String typeName, String message)
+    {
         List<Map<String, Object>> framesList = new List<Map<String, Object>>();
 
-        String[] frames = exc.getStackTraceString().split('\n');
+        String[] frames = stackTraceString.split('\n');
         for (String frameStr : frames) {
-            if (frameStr == '()') {
+            if (frameStr == '()' || frameStr == '') {
                 continue;
             } else if (frameStr.toLowerCase() == 'caused by') {
                 break;
@@ -144,32 +155,58 @@ public with sharing class DataBuilder {
             Map<String, Object> frameMap = new Map<String, Object>();
             frameMap.put('filename', frameStr);
 
-            String className = frameStr.split(':')[0];
-            String methodName = '';
-            if (className != 'AnonymousBlock') {
-                className = className.split('\\.')[1];
-                methodName = frameStr.split(':')[0].split('\\.')[2];
+            String[] location = frameStr.split(':')[0].split('\\.');
+            Integer locationLength = location.size();
+            String className = '(unknown)';
+            String methodName = '(unknown)';
+            switch on location[0] {
+                when 'Class' {
+                    if (locationLength > 1) {
+                        className = location[1];
+                    }
+                    if (locationLength > 2) {
+                        methodName = location[2];
+                    }
+                }
+                when 'Trigger' {
+                    className = 'Trigger';
+                    if (locationLength > 1) {
+                        methodName = location[1];
+                    }
+                }
+                when else { // e.g. "AnonymousBlock"
+                    className = 'Unknown';
+                    methodName = location[0];
+                }
             }
 
             frameMap.put('class_name', className);
             frameMap.put('method', methodName);
 
-            Pattern linePattern = Pattern.compile('line (\\d+)');
-            Matcher lineMatcher = linePattern.matcher(frameStr);
-            lineMatcher.find();
-            frameMap.put('lineno', Integer.valueOf(lineMatcher.group(1)));
+            try {
+                Pattern linePattern = Pattern.compile('line (\\d+)');
+                Matcher lineMatcher = linePattern.matcher(frameStr);
+                lineMatcher.find();
+                frameMap.put('lineno', Integer.valueOf(lineMatcher.group(1)));
+            } catch (StringException e) {
+                frameMap.put('lineno', '(unknown)');
+            }
 
-            Pattern colPattern = Pattern.compile('column (\\d+)');
-            Matcher colMatcher = colPattern.matcher(frameStr);
-            colMatcher.find();
-            frameMap.put('colno', Integer.valueOf(colMatcher.group(1)));
+            try {
+                Pattern colPattern = Pattern.compile('column (\\d+)');
+                Matcher colMatcher = colPattern.matcher(frameStr);
+                colMatcher.find();
+                frameMap.put('colno', Integer.valueOf(colMatcher.group(1)));
+            } catch (StringException e) {
+                frameMap.put('colno', '(unknown)');
+            }
 
             framesList.add(frameMap);
         }
 
         Map<String, Object> excMap = new Map<String, Object>();
-        excMap.put('class', exc.getTypeName());
-        excMap.put('message', exc.getMessage());
+        excMap.put('class', typeName);
+        excMap.put('message', message);
 
         return buildTraceStructure(excMap, framesList);
     }

--- a/force-app/main/default/classes/Notifier.cls
+++ b/force-app/main/default/classes/Notifier.cls
@@ -26,6 +26,8 @@ public with sharing class Notifier
 
     public HttpResponse send(Map<String, Object> payload, SendMethod method)
     {
+        if(!RollbarSettings__c.getOrgDefaults().SendReports__c) { return null; }
+
         return methodSend(JSON.serialize(payload), method);
     }
 
@@ -74,6 +76,10 @@ public with sharing class Notifier
         HttpResponse response = http.send(request);
 
         return response;
+    }
+
+    public Config config() {
+        return config;
     }
 
     private Config config;

--- a/force-app/main/default/classes/Rollbar.cls
+++ b/force-app/main/default/classes/Rollbar.cls
@@ -22,9 +22,11 @@ global with sharing class Rollbar {
 
     public static Rollbar init()
     {
+        RollbarSettings__c settings = RollbarSettings__c.getOrgDefaults();
+
         return Rollbar.init(
-            RollbarSettings__c.getOrgDefaults().AccessToken__c,
-            UserInfo.getOrganizationName()
+            settings.AccessToken__c,
+            settings.Environment__c
         );
     }
 
@@ -100,6 +102,10 @@ global with sharing class Rollbar {
 
     public Notifier notifier() {
         return notifier;
+    }
+
+    public Config config() {
+        return config;
     }
 
     private static Rollbar instance = null;

--- a/force-app/main/default/classes/RollbarConfigureController.cls
+++ b/force-app/main/default/classes/RollbarConfigureController.cls
@@ -1,6 +1,12 @@
 public with sharing class RollbarConfigureController {
 
     protected RollbarSettings__c settings { get; set; }
+
+    public Boolean reportUncaughtExceptions { get; set; }
+    public Boolean reportFlowErrors { get; set; }
+    public Boolean reportUnknownEmailType { get; set; }
+    public Boolean sendReports { get; set; }
+    public String environment { get; set; }
     public String accessToken {
         get {
             return this.settings.AccessToken__c;
@@ -21,6 +27,11 @@ public with sharing class RollbarConfigureController {
 
     public RollbarConfigureController() {
         this.settings = RollbarSettings__c.getOrgDefaults();
+        this.reportUncaughtExceptions = this.settings.ReportUncaughtExceptions__c;
+        this.reportFlowErrors = this.settings.ReportFlowErrors__c;
+        this.reportUnknownEmailType = this.settings.ReportUnknownEmailType__c;
+        this.sendReports = this.settings.SendReports__c;
+        this.environment = this.settings.Environment__c;
         updateConfigState();
     }
 
@@ -35,12 +46,12 @@ public with sharing class RollbarConfigureController {
         return null;
     }
 
-    public Pagereference save()
+    public Pagereference verifyToken()
     {
         String message;
 
         try {
-            Config config = new Config(this.accessToken, UserInfo.getOrganizationName());
+            Config config = new Config(this.accessToken, this.settings.Environment__c);
             message = RollbarInstaller.verifyToken(config);
         } catch (RollbarNotInitializedException e) {
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, 'Provided access token is incorrect.'));
@@ -49,6 +60,27 @@ public with sharing class RollbarConfigureController {
             ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Error, message));
         }
         this.settings = RollbarSettings__c.getOrgDefaults();
+        this.reportUncaughtExceptions = this.settings.ReportUncaughtExceptions__c;
+        this.reportFlowErrors = this.settings.ReportFlowErrors__c;
+        this.reportUnknownEmailType = this.settings.ReportUnknownEmailType__c;
+        this.sendReports = this.settings.SendReports__c;
+        this.environment = this.settings.Environment__c;
+        updateConfigState();
+        return null;
+    }
+
+    public Pagereference updateSettings()
+    {
+        String message;
+
+        this.settings = RollbarSettings__c.getOrgDefaults();
+        this.settings.ReportUncaughtExceptions__c = this.reportUncaughtExceptions;
+        this.settings.ReportFlowErrors__c = this.reportFlowErrors;
+        this.settings.ReportUnknownEmailType__c = this.reportUnknownEmailType;
+        this.settings.SendReports__c = this.sendReports;
+        this.settings.Environment__c = this.environment;
+        upsert this.settings;
+
         updateConfigState();
         return null;
     }

--- a/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
+++ b/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
@@ -32,6 +32,7 @@ global class RollbarExceptionEmailHandler implements Messaging.InboundEmailHandl
   }
 
     private void parseAndSend(Messaging.InboundEmail email) {
+        RollbarSettings__c settings = RollbarSettings__c.getOrgDefaults();
         String emailBody = '';
 
         Rollbar.init();
@@ -39,16 +40,22 @@ global class RollbarExceptionEmailHandler implements Messaging.InboundEmailHandl
         // The fromName field is the most reliable known way to differentiate
         // Exception and Flow email types.
         if (email.fromName == ExceptionEmailParser.fromName()) {
+            if (!settings.ReportUncaughtExceptions__c) { return; }
+
             emailBody = email.plainTextBody;
             ExceptionData exData = ExceptionEmailParser.parse(emailBody);
 
             Rollbar.log(exData);
         } else if (email.fromName == FlowEmailParser.fromName()) {
+            if (!settings.ReportFlowErrors__c) { return; }
+
             emailBody = email.htmlBody;
             List<Telemetry> telemetry = FlowEmailParser.parseTelemetry(emailBody);
 
             Rollbar.log('error', email.subject, null, telemetry, SendMethod.SYNC);
         } else {
+            if (!settings.ReportUnknownEmailType__c) { return; }
+
             // Unknown email type.
             // TODO: Use emailBody and fromName in notifier.diagnostic
 

--- a/force-app/main/default/classes/RollbarInstaller.cls
+++ b/force-app/main/default/classes/RollbarInstaller.cls
@@ -64,13 +64,11 @@ public with sharing class RollbarInstaller {
     {
         if (!rollbarApiEndpointAllowed(apiDomain)) {
             MetadataService.createRemoteSiteSetting('RollbarAPI', apiDomain);
-
-            settings.SalesforceApiEnabled__c = metadataApiAllowed();
-            settings.RollbarApiEnabled__c = rollbarApiEndpointAllowed(apiDomain);
-            settings.RollbarNetworkAccess__c = rollbarPingSuccessful();
-        } else if (!settings.RollbarNetworkAccess__c) {
-            settings.RollbarNetworkAccess__c = rollbarPingSuccessful();
         }
+
+        settings.SalesforceApiEnabled__c = metadataApiAllowed();
+        settings.RollbarApiEnabled__c = rollbarApiEndpointAllowed(apiDomain);
+        settings.RollbarNetworkAccess__c = rollbarPingSuccessful();
     }
 
     public static void enableApexNotificationsForwarding(RollbarSettings__c settings)

--- a/force-app/main/default/objects/RollbarSettings__c/fields/Environment__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/Environment__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Environment__c</fullName>
+    <externalId>false</externalId>
+    <label>Environment</label>
+    <length>80</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/RollbarSettings__c/fields/ReportFlowErrors__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/ReportFlowErrors__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ReportFlowErrors__c</fullName>
+    <defaultValue>true</defaultValue>
+    <externalId>false</externalId>
+    <label>Report Flow Errors</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/RollbarSettings__c/fields/ReportUncaughtExceptions__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/ReportUncaughtExceptions__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ReportUncaughtExceptions__c</fullName>
+    <defaultValue>true</defaultValue>
+    <externalId>false</externalId>
+    <label>Report Uncaught Exceptions</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/RollbarSettings__c/fields/ReportUnknownEmailType__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/ReportUnknownEmailType__c.field-meta.xml
@@ -1,0 +1,10 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ReportUnknownEmailType__c</fullName>
+    <defaultValue>true</defaultValue>
+    <externalId>false</externalId>
+    <label>Report Unknown Error Emails</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/RollbarSettings__c/fields/SendReports__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/SendReports__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SendReports__c</fullName>
+    <defaultValue>true</defaultValue>
+    <externalId>false</externalId>
+    <label>Send Reports</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/pages/RollbarConfigure.page
+++ b/force-app/main/default/pages/RollbarConfigure.page
@@ -174,7 +174,7 @@
                             <apex:inputText value="{!accessToken}" id="rollbarAccessToken" html-placeholder="Rollbar Access Token" />
                         </p>
                         <div class="next-step">
-                            <apex:commandButton action="{!save}" value="Save and Verify" id="rollbarConfigure" reRender="setup" />
+                            <apex:commandButton action="{!verifyToken}" value="Save and Verify" id="rollbarConfigure" reRender="setup" />
                         </div>
                     </apex:form>
                 </apex:outputPanel>
@@ -205,13 +205,34 @@
                 <apex:outputPanel rendered="{!configState == 'ConfigState.COMPLETE'}" layout="block">
                     <div class="section">
                         <div class="section">
-                            <h4>Update Rollbar Token</h4>
+                            <h4>Update Settings</h4>
                             <apex:form>
+                                <p>
+                                    <apex:inputCheckbox value="{!reportUncaughtExceptions}" label="Report Uncaught Exceptions" />
+                                    <span>Report Uncaught Exceptions</span>
+                                </p>
+                                <p>
+                                    <apex:inputCheckbox value="{!reportFlowErrors}" label="Report Flow Errors" />
+                                    <span>Report Flow Errors</span>
+                                </p>
+                                <p>
+                                    <apex:inputCheckbox value="{!reportUnknownEmailType}" label="Report Unknown Error Emails" />
+                                    <span>Report Unknown Error Emails</span>
+                                </p>
+                                <p>
+                                    <apex:inputCheckbox value="{!sendReports}" label="Send Events To Rollbar" />
+                                    <span>Send Events To Rollbar</span>
+                                </p>
+                                <p>
+                                    <h4>Environment</h4>
+                                    <apex:inputText value="{!environment}" id="rollbarEnvironment" html-placeholder="Rollbar Environment" />
+                                </p>
                                 <p class="center">
+                                    <h4>Access Token</h4>
                                     <apex:inputText value="{!accessToken}" id="rollbarAccessToken" html-placeholder="Rollbar Access Token" />
                                 </p>
                                 <div class="next-step">
-                                    <apex:commandButton action="{!save}" value="Update and Verify" id="rollbarConfigure" reRender="setup" />
+                                    <apex:commandButton action="{!updateSettings}" value="Update" id="rollbarConfigure" reRender="setup" />
                                 </div>
                             </apex:form>
                         </div>

--- a/force-app/main/default/tests/DataBuilderTest.cls
+++ b/force-app/main/default/tests/DataBuilderTest.cls
@@ -213,4 +213,51 @@ public class DataBuilderTest
         System.assertEquals(expected.get('line'), frameMap.get('lineno'));
         System.assertEquals(expected.get('column'), frameMap.get('colno'));
     }
+
+    @isTest
+    static void testBuildEachFrameType()
+    {
+        String[] input = new String[]{
+            'Class.HelloWorld.hello: line 32, column 1', // Normal class context
+            'Trigger.Log: line 8, column 1', // Trigger context
+            'AnonymousBlock: line 2, column 1', // Anonymous context
+            '(rollbar)', // Stripped frame
+            'Class: line 32', // Invalid
+            'Trigger: column 1' // Invalid
+        };
+
+        List <Map<String, Object>> output = new List <Map<String, Object>> {
+            new Map<String, Object>{
+                'class_name' => 'HelloWorld', 'method' => 'hello', 'lineno' => 32, 'colno' => 1
+            },
+            new Map<String, Object>{
+                'class_name' => 'Trigger', 'method' => 'Log', 'lineno' => 8, 'colno' => 1
+            },
+            new Map<String, Object>{
+                'class_name' => 'Unknown', 'method' => 'AnonymousBlock', 'lineno' => 2, 'colno' => 1
+            },
+            new Map<String, Object>{
+                'class_name' => 'Unknown', 'method' => '(rollbar)', 'lineno' => '(unknown)', 'colno' => '(unknown)'
+            },
+            new Map<String, Object>{
+                'class_name' => '(unknown)', 'method' => '(unknown)', 'lineno' => 32, 'colno' => '(unknown)'
+            },
+            new Map<String, Object>{
+                'class_name' => 'Trigger', 'method' => '(unknown)', 'lineno' => '(unknown)', 'colno' => 1
+            }
+        };
+
+        DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
+
+        for(Integer i = 0; i < input.size(); i++){
+            Map<String, Object> result = subject.buildTraceBody(input[i], 'Exception', 'Error message');
+            Map<String, Object> trace = (Map<String, Object>)result.get('trace');
+            Map<String, Object> frame = ((List<Map<String, Object>>)trace.get('frames'))[0];
+
+            System.assertEquals(frame.get('class_name'), output[i].get('class_name'));
+            System.assertEquals(frame.get('method'), output[i].get('method'));
+            System.assertEquals(frame.get('lineno'), output[i].get('lineno'));
+            System.assertEquals(frame.get('colno'), output[i].get('colno'));
+        }
+    }
 }

--- a/force-app/main/default/tests/NotifierTest.cls
+++ b/force-app/main/default/tests/NotifierTest.cls
@@ -2,13 +2,16 @@
 public class NotifierTest {
     @isTest
     public static void testLogMessage(){
+        insert new RollbarSettings__c(SendReports__c = true);
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
         Config config = new Config('foo', 'bar');
 
         Notifier subject = new Notifier(config);
 
+        Test.startTest();
         HttpResponse response = subject.log('info', 'Message from the Apex SDK', null, null, SendMethod.SYNC);
+        Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
 
@@ -27,6 +30,7 @@ public class NotifierTest {
 
     @isTest
     public static void testLogException(){
+        insert new RollbarSettings__c(SendReports__c = true);
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
         Config config = new Config('foo', 'bar');
@@ -35,7 +39,9 @@ public class NotifierTest {
 
         DataBuilderTestException exc = new DataBuilderTestException();
 
+        Test.startTest();
         HttpResponse response = subject.log('error', exc, null, SendMethod.SYNC);
+        Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
 
@@ -54,6 +60,7 @@ public class NotifierTest {
 
     @isTest
     public static void testLogExceptionData(){
+        insert new RollbarSettings__c(SendReports__c = true);
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
         Config config = new Config('foo', 'bar');
@@ -72,7 +79,9 @@ public class NotifierTest {
 
         ExceptionData exData = ExceptionData.fromMap(expected);
 
+        Test.startTest();
         HttpResponse response = subject.log(exData, SendMethod.SYNC);
+        Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
 
@@ -87,5 +96,21 @@ public class NotifierTest {
         }
 
         System.assertEquals(0, err);
+    }
+
+    @isTest
+    public static void testSendReportsDisabled(){
+        insert new RollbarSettings__c(SendReports__c = false);
+        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+
+        Config config = new Config('foo', 'bar');
+
+        Notifier subject = new Notifier(config);
+
+        Test.startTest();
+        HttpResponse response = subject.log('info', 'Message from the Apex SDK', null, null, SendMethod.SYNC);
+        Test.stopTest();
+
+        System.assertEquals(response, null);
     }
 }

--- a/force-app/main/default/tests/RollbarApiAssertNotCalledMock.cls
+++ b/force-app/main/default/tests/RollbarApiAssertNotCalledMock.cls
@@ -1,0 +1,9 @@
+// Use this mock to assert the API is not called.
+@isTest
+global class RollbarApiAssertNotCalledMock implements HttpCalloutMock {
+    global HTTPResponse respond(HTTPRequest req) {
+        System.assert(false, 'Rollbar API should not be called.');
+
+        return null;
+    }
+}

--- a/force-app/main/default/tests/RollbarApiAssertNotCalledMock.cls-meta.xml
+++ b/force-app/main/default/tests/RollbarApiAssertNotCalledMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/tests/RollbarApiVerifyTelemetryCalloutMock.cls
+++ b/force-app/main/default/tests/RollbarApiVerifyTelemetryCalloutMock.cls
@@ -5,7 +5,7 @@ global class RollbarApiVerifyTelemetryCalloutMock implements HttpCalloutMock {
         Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(body);
         Map<String, Object> data = (Map<String, Object>)payload.get('data');
         Map<String, Object> messageBody = (Map<String, Object>)data.get('body');
-        List<Map<String, Object>> telemetry = (List<Map<String, Object>>)messageBody.get('telemetry');
+        List<Object> telemetry = (List<Object>)messageBody.get('telemetry');
 
         System.assert(telemetry.size() > 0);
 

--- a/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls
+++ b/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls
@@ -5,16 +5,38 @@ private class RollbarExceptionEmailHandlerTest {
     public static void testFlowEmail() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyTelemetryCalloutMock());
 
+        upsert new RollbarSettings__c(AccessToken__c = 'test-token', ReportFlowErrors__c = true);
+
+        Test.startTest();
+        Messaging.InboundEnvelope envelope = new Messaging.InboundEnvelope();
+        Messaging.InboundEmail email = new Messaging.InboundEmail();
+        email.fromName = 'FlowApplication';
+        email.subject = 'Test Flow';
+        email.htmlBody = '<html>Test Flow block 1\n\nTest Flow Block 2</html>\n\n';
+
+        RollbarExceptionEmailHandler handler = new RollbarExceptionEmailHandler();
+        handler.handleInboundEmail(email, envelope);
+        Test.stopTest();
+
+        // Asserts valid payload in the mock.
+    }
+
+    @isTest
+    public static void testFlowEmailDisabled() {
+        Test.setMock(HttpCalloutMock.class, new RollbarApiAssertNotCalledMock());
+
+        upsert new RollbarSettings__c(AccessToken__c = 'test-token', ReportFlowErrors__c = false);
+
+        Test.startTest();
         Messaging.InboundEnvelope envelope = new Messaging.InboundEnvelope();
         Messaging.InboundEmail email = new Messaging.InboundEmail();
         email.fromName = 'FlowApplication';
         email.htmlBody = '<html>Test Flow message</html>\n\n';
 
-        Rollbar.init('test-token', 'test-env');
-
         RollbarExceptionEmailHandler handler = new RollbarExceptionEmailHandler();
         handler.handleInboundEmail(email, envelope);
+        Test.stopTest();
 
-        // Asserts valid payload in the mock.
+        // Asserts API is not called in the mock.
     }
 }

--- a/force-app/main/default/tests/RollbarTest.cls
+++ b/force-app/main/default/tests/RollbarTest.cls
@@ -4,8 +4,12 @@ public class RollbarTest {
     public static void testLogMessage() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
+        insert new RollbarSettings__c(SendReports__c = true);
+
+        Test.startTest();
         Rollbar.init('test-token', 'test-env');
         HttpResponse response = Rollbar.log('info', 'Message from the Apex SDK', SendMethod.SYNC);
+        Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
     }
@@ -14,7 +18,7 @@ public class RollbarTest {
     public static void testLogMessageFuture() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyRequestCalloutMock());
 
-        insert new RollbarSettings__c(AccessToken__c = 'test-token');
+        insert new RollbarSettings__c(AccessToken__c = 'test-token', SendReports__c = true);
 
         Test.startTest();
         Rollbar.log('info', 'Message from the Apex SDK', SendMethod.FUTURE);
@@ -27,7 +31,7 @@ public class RollbarTest {
     public static void testLogMessageEvent() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyRequestCalloutMock());
 
-        insert new RollbarSettings__c(AccessToken__c = 'test-token');
+        insert new RollbarSettings__c(AccessToken__c = 'test-token', SendReports__c = true);
 
         Test.startTest();
         Rollbar.log('info', 'Message from the Apex SDK', SendMethod.EVENT);
@@ -40,9 +44,12 @@ public class RollbarTest {
     public static void testLogMessageWithCustomDataAndTelemetry() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
+        insert new RollbarSettings__c(SendReports__c = true);
+
         Map<String, Object> customData = new Map<String, Object>{ 'foo' => 'bar' };
         List<Telemetry> telemetryList = new List<Telemetry>();
 
+        Test.startTest();
         Rollbar.init('test-token', 'test-env');
         HttpResponse response = Rollbar.log(
             'info',
@@ -51,6 +58,7 @@ public class RollbarTest {
             telemetryList,
             SendMethod.SYNC
         );
+        Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
     }
@@ -59,8 +67,12 @@ public class RollbarTest {
     public static void testLogException() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
 
+        insert new RollbarSettings__c(SendReports__c = true);
+
+        Test.startTest();
         Rollbar.init('test-token', 'test-env');
         HttpResponse response = Rollbar.log(new DataBuilderTestException(), SendMethod.SYNC);
+        Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
     }
@@ -68,6 +80,8 @@ public class RollbarTest {
     @isTest
     public static void testLogExceptionData() {
         Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+
+        insert new RollbarSettings__c(SendReports__c = true);
 
         Map<String, Object> exDataMap = new Map<String, Object>();
         exDataMap.put('environment', 'Sandbox');
@@ -79,9 +93,25 @@ public class RollbarTest {
         exDataMap.put('line', 14);
         exDataMap.put('column', 12);
 
+        Test.startTest();
         Rollbar.init('test-token', 'test-env');
         HttpResponse response = Rollbar.log(ExceptionData.fromMap(exDataMap));
+        Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
+    }
+
+    @isTest
+    public static void testConfigEnvironment() {
+        insert new RollbarSettings__c(AccessToken__c = 'test-token', Environment__c = 'test-environment');
+
+        Test.startTest();
+        Rollbar instance = Rollbar.init(); // use environment from RollbarSettings
+        Test.stopTest();
+
+        System.assertEquals(instance.config().environment(), 'test-environment');
+        System.assertEquals(instance.config().accessToken(), 'test-token');
+        System.assertEquals(instance.notifier().config().environment(), 'test-environment');
+        System.assertEquals(instance.notifier().config().accessToken(), 'test-token');
     }
 }

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -35,6 +35,7 @@
         <members>TelemetryTest</members>
 
         <!-- test helpers -->
+        <members>RollbarApiAssertNotCalledMock</members>
         <members>RollbarApiCalloutMock</members>
         <members>RollbarApiVerifyRequestCalloutMock</members>
         <members>RollbarApiVerifyTelemetryCalloutMock</members>


### PR DESCRIPTION
Adds new options to the setup and configuration pages:

**ReportUncaughtExceptions** and **ReportFlowErrors**
Salesforce routes exceptions and Flow/Process errors to the same email handler. These options allow Rollbar to handle only Exceptions or only Flow/Process Errors, or both. 

**ReportUnknownEmailType**
The email handler may also receive email types besides Exception and Flow/Process emails. This option allows sending these to Rollbar as generic messages, or not.

**SendReports**
This enables/disables sending occurrences to Rollbar, allowing sedning to be disabled without needing to uninstall the package.

**Environment**
Allows setting the environment string sent to Rollbar with each report. Unlike the option in the Config object in earlier package versions, this setting is global, and works for all occurrences including uncaught exceptions and Flow/Process errors.


_A few other fixes have been bundled into this PR. These are each in their own commit for easier review:_

**Fixed stack frame parsing**
Several known stack frame formats weren't being handled correctly and would cause unhandled exceptions, including stack frames from Trigger classes, and stack frames from test classes. This update handles known and unknown cases safely. 
6d6bc3c

**Setup works when API permissions are already set**
After uninstall/reinstall, or partial install, it's possible to have Rollbar API callout permissions already enabled in Salesforce. This update ensures Setup can continue successfully in this state. 03bd64c

**Fixes a wrong type cast on assignment** e7aafd6

**Add the deploy dir to .gitignore** 0c98278

