### PR TITLE
Publish API callout mock, so customer org tests will work.

### DIFF
--- a/force-app/main/default/tests/NotifierTest.cls
+++ b/force-app/main/default/tests/NotifierTest.cls
@@ -3,7 +3,7 @@ public class NotifierTest {
     @isTest
     public static void testLogMessage(){
         insert new RollbarSettings__c(SendReports__c = true);
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         Config config = new Config('foo', 'bar');
 
@@ -31,7 +31,7 @@ public class NotifierTest {
     @isTest
     public static void testLogException(){
         insert new RollbarSettings__c(SendReports__c = true);
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         Config config = new Config('foo', 'bar');
 
@@ -61,7 +61,7 @@ public class NotifierTest {
     @isTest
     public static void testLogExceptionData(){
         insert new RollbarSettings__c(SendReports__c = true);
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         Config config = new Config('foo', 'bar');
 
@@ -101,7 +101,7 @@ public class NotifierTest {
     @isTest
     public static void testSendReportsDisabled(){
         insert new RollbarSettings__c(SendReports__c = false);
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         Config config = new Config('foo', 'bar');
 

--- a/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls
+++ b/force-app/main/default/tests/RollbarExceptionEmailHandlerTest.cls
@@ -3,7 +3,7 @@ private class RollbarExceptionEmailHandlerTest {
 
     @isTest
     public static void testFlowEmail() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyTelemetryCalloutMock());
+        RollbarTestHelper.setMock(new RollbarApiVerifyTelemetryCalloutMock());
 
         upsert new RollbarSettings__c(AccessToken__c = 'test-token', ReportFlowErrors__c = true);
 
@@ -23,7 +23,7 @@ private class RollbarExceptionEmailHandlerTest {
 
     @isTest
     public static void testFlowEmailDisabled() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiAssertNotCalledMock());
+        RollbarTestHelper.setMock(new RollbarApiAssertNotCalledMock());
 
         upsert new RollbarSettings__c(AccessToken__c = 'test-token', ReportFlowErrors__c = false);
 

--- a/force-app/main/default/tests/RollbarTest.cls
+++ b/force-app/main/default/tests/RollbarTest.cls
@@ -2,7 +2,7 @@
 public class RollbarTest {
     @isTest
     public static void testLogMessage() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         insert new RollbarSettings__c(SendReports__c = true);
 
@@ -16,7 +16,7 @@ public class RollbarTest {
 
     @isTest
     public static void testLogMessageFuture() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyRequestCalloutMock());
+        RollbarTestHelper.setMock(new RollbarApiVerifyRequestCalloutMock());
 
         insert new RollbarSettings__c(AccessToken__c = 'test-token', SendReports__c = true);
 
@@ -29,7 +29,7 @@ public class RollbarTest {
 
     @isTest
     public static void testLogMessageEvent() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiVerifyRequestCalloutMock());
+        RollbarTestHelper.setMock(new RollbarApiVerifyRequestCalloutMock());
 
         insert new RollbarSettings__c(AccessToken__c = 'test-token', SendReports__c = true);
 
@@ -42,7 +42,7 @@ public class RollbarTest {
 
     @isTest
     public static void testLogMessageWithCustomDataAndTelemetry() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         insert new RollbarSettings__c(SendReports__c = true);
 
@@ -65,7 +65,7 @@ public class RollbarTest {
 
     @isTest
     public static void testLogException() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         insert new RollbarSettings__c(SendReports__c = true);
 
@@ -79,7 +79,7 @@ public class RollbarTest {
 
     @isTest
     public static void testLogExceptionData() {
-        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+        RollbarTestHelper.setDefaultMock();
 
         insert new RollbarSettings__c(SendReports__c = true);
 

--- a/force-app/main/default/tests/RollbarTestHelper.cls
+++ b/force-app/main/default/tests/RollbarTestHelper.cls
@@ -1,0 +1,10 @@
+@isTest
+global class RollbarTestHelper {
+    global static void setDefaultMock() {
+        Test.setMock(HttpCalloutMock.class, new RollbarApiCalloutMock());
+    }
+
+    global static void setMock(HttpCalloutMock mock) {
+        Test.setMock(HttpCalloutMock.class, mock);
+    }
+}

--- a/force-app/main/default/tests/RollbarTestHelper.cls-meta.xml
+++ b/force-app/main/default/tests/RollbarTestHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -40,6 +40,7 @@
         <members>RollbarApiVerifyRequestCalloutMock</members>
         <members>RollbarApiVerifyTelemetryCalloutMock</members>
         <members>DataBuilderTestException</members>
+        <members>RollbarTestHelper</members>
     </types>
 
     <types>


### PR DESCRIPTION
Salesforce won't let users of managed packages call `Test.setMock` for callouts in the managed package. Yet they also require that _all_ callouts are mocked. 

This PR provides a wrapper so `Test.setMock` can be called within the package, making it possible to mock the API calls.

The Rollbar package tests are also updated to use this helper class internally.

The user tests can use:
```
rollbar.RollbarTestHelper.setDefaultMock();
```
Or
```
rollbar.RollbarTestHelper.setMock(new CustomMock);
```

Example:
```
@isTest
public class CalloutTest {
    @isTest
    public static void calloutIsMocked(){
        // Set the test mock.
        rollbar.RollbarTestHelper.setDefaultMock();

        // Also initialize a test token. (Can be any string.)
        insert new rollbar__RollbarSettings__c(rollbar__AccessToken__c = 'test-token');
        
        Test.startTest();
        // Any Rollbar callouts (e.g. rollbar.Rollbar.log()) should work.
        Test.stopTest();
    }
}
```