### PR TITLE
Item class and person data

### DIFF
--- a/force-app/main/default/classes/DataBuilder.cls
+++ b/force-app/main/default/classes/DataBuilder.cls
@@ -1,6 +1,10 @@
 public with sharing class DataBuilder {
+    private RollbarSettings__c settings { get; set; }
+
     public DataBuilder(Config config) {
         this.config = config;
+
+        this.settings = RollbarSettings__c.getOrgDefaults();
     }
 
     public Map<String, Object> buildPayload(String level, Item item) {
@@ -30,8 +34,9 @@ public with sharing class DataBuilder {
             data.put('custom', item.custom);
         }
 
-        // TODO: if config.personData
-        data.put('person', buildPersonData(item));
+        if (personDataEnabled()) {
+            data.put('person', buildPersonData(item));
+        }
 
         return data;
     }
@@ -225,6 +230,10 @@ public with sharing class DataBuilder {
         return telemetryList;
     }
 
+    private Boolean personDataEnabled() {
+        return settings.CaptureUserId__c || settings.CaptureUsername__c || settings.CaptureEmail__c;
+    }
+
     private Map<String, Object> buildPersonData(Item item) {
         if (item.isUncaught) {
             // The uncaught error handlers won't have anything meaningful at
@@ -238,9 +247,9 @@ public with sharing class DataBuilder {
     private Map<String, Object> buildCurrentPersonData() {
         Map<String, Object> data = new Map<String, Object>();
 
-        data.put('id', UserInfo.getUserId());
-        data.put('username', UserInfo.getUserName());
-        data.put('email', UserInfo.getUserEmail());
+        if (settings.CaptureUserId__c) { data.put('id', UserInfo.getUserId()); }
+        if (settings.CaptureUsername__c) { data.put('username', UserInfo.getUserName()); }
+        if (settings.CaptureEmail__c) { data.put('email', UserInfo.getUserEmail()); }
 
         return data;
     }
@@ -256,9 +265,9 @@ public with sharing class DataBuilder {
                 LIMIT 1
             ];
 
-            data.put('id', personId);
-            data.put('username', u.Username);
-            data.put('email', u.Email);
+            if (settings.CaptureUserId__c) { data.put('id', personId); }
+            if (settings.CaptureUsername__c) { data.put('username', u.Username); }
+            if (settings.CaptureEmail__c) { data.put('email', u.Email); }
         }
 
         return data; // return the map whether filled or empty

--- a/force-app/main/default/classes/DataBuilder.cls
+++ b/force-app/main/default/classes/DataBuilder.cls
@@ -3,114 +3,83 @@ public with sharing class DataBuilder {
         this.config = config;
     }
 
-    public Map<String, Object> buildPayload(String level, String message, Map<String, Object> custom, List<Telemetry> telemetry)
-    {
-        return buildPayloadStructure(level, buildMessageBody(message, telemetry), custom);
+    public Map<String, Object> buildPayload(String level, Item item) {
+        Map<String, Object> payload = new Map<String, Object>();
+        Map<String, Object> data = buildData(level, item);
+
+        payload.put('access_token', config.accessToken());
+        payload.put('data', data);
+
+        return payload;
     }
 
-    public Map<String, Object> buildPayload(String level, Exception exc, Map<String, Object> custom)
-    {
-        return buildPayloadStructure(level, buildExceptionBody(exc), custom);
-    }
+    private Map<String, Object> buildData(String level, Item item) {
+        Map<String, Object> notifierMap = new Map<String, Object>();
+        notifierMap.put('name', Notifier.NAME);
+        notifierMap.put('version', Notifier.VERSION);
+        notifierMap.put('diagnostic', item.diagnostic);
 
-    public Map<String, Object> buildPayload(ExceptionData exData)
-    {
-        Map<String, Object> custom = new Map<String, Object>();
-        custom.put('context', exData.context());
+        Map<String, Object> data = new Map<String, Object>();
+        data.put('notifier', notifierMap);
+        data.put('level', level);
+        data.put('environment', item.environment);
+        data.put('framework', 'apex');
+        data.put('body', buildBody(item));
 
-        return buildPayloadStructure('error', buildTraceBody(exData), custom);
-    }
-
-    private Map<String, Object> buildExceptionBody(Exception exc)
-    {
-        if (exc.getCause() == null) {
-            return buildTraceBody(exc);
-        } else {
-            return buildTraceChainBody(exc);
+        if (item.custom != null) {
+            data.put('custom', item.custom);
         }
+
+        return data;
     }
 
-    private Map<String, Object> buildTraceChainBody(Exception exc)
-    {
-        Map<String, Object> outterExTrace = (Map<String, Object>)this.buildTraceBody(exc).get('trace');
-        Map<String, Object> innerExTrace = (Map<String, Object>)this.buildTraceBody(exc.getCause()).get('trace');
+    private Map<String, Object> buildBody(Item item) {
+        Map<String, Object> body;
 
-        List<Map<String, Object>> traceChainList = new List<Map<String, Object>>();
-        traceChainList.add(outterExTrace);
-        traceChainList.add(innerExTrace);
+        switch on item.payloadType {
+            when MESSAGE {
+                body = buildMessageBody(item);
+            }
+            when EXC {
+                body = buildExceptionBody(item);
+            }
+            when EXDATA {
+                body = buildExDataBody(item);
+            }
+        }
 
-
-        Map<String, Object> body = new Map<String, Object>();
-        body.put('trace_chain', traceChainList);
+        if (item.telemetry != null) {
+            body.put('telemetry', buildTelemetry(item));
+        }
 
         return body;
     }
 
-    private Map<String, Object> buildPayloadStructure(
-        String level,
-        Map<String, Object> body,
-        Map<String, Object> custom
-    ) {
-        Map<String, Object> data = this.buildDataStructure(
-            level,
-            this.config.environment(),
-            body,
-            custom
-        );
-
-        Map<String, Object> structure = new Map<String, Object>();
-        structure.put('access_token', this.config.accessToken());
-        structure.put('data', data);
-        return structure;
-    }
-
-    private Map<String, Object> buildDataStructure(
-        String level,
-        String environment,
-        Map<String, Object> body,
-        Map<String, Object> custom
-    ) {
-
-        Map<String, Object> notifierMap = new Map<String, Object>();
-        notifierMap.put('name', Notifier.NAME);
-        notifierMap.put('version', Notifier.VERSION);
-
-        Map<String, Object> structure = new Map<String, Object>();
-        structure.put('notifier', notifierMap);
-        structure.put('level', level);
-        structure.put('environment', environment);
-        structure.put('framework', 'apex');
-        structure.put('body', body);
-
-        if (custom != null) {
-            structure.put('custom', custom);
-        }
-
-        return structure;
-    }
-
-    private Map<String, Object> buildMessageBody(String message, List<Telemetry> telemetry)
-    {
+    private Map<String, Object> buildMessageBody(Item item) {
         Map<String, Object> messageMap = new Map<String, Object>();
-        messageMap.put('body', message);
+        messageMap.put('body', item.message);
 
         Map<String, Object> body = new Map<String, Object>();
         body.put('message', messageMap);
 
-        if (telemetry != null) {
-            List<Object> telemetryList = new List<Object>();
-
-            for (Telemetry t : telemetry) {
-                telemetryList.add(t.toMap());
-            }
-            body.put('telemetry', telemetryList);
-        }
-
         return body;
     }
 
-    private Map<String, Object> buildTraceBody(ExceptionData exData)
-    {
+    private Map<String, Object> buildExceptionBody(Item item) {
+        Exception exc = item.exc;
+
+        if (exc.getCause() == null) {
+            return buildTraceBody(exc);
+        }
+
+        return buildTraceChainBody(exc);
+    }
+
+    private Map<String, Object> buildExDataBody(Item item) {
+        return buildTraceBody(item.exData);
+    }
+
+    private Map<String, Object> buildTraceBody(ExceptionData exData) {
         List<Map<String, Object>> framesList = new List<Map<String, Object>>();
 
         Map<String, Object> frameMap = new Map<String, Object>();
@@ -129,19 +98,35 @@ public with sharing class DataBuilder {
         return buildTraceStructure(excMap, framesList);
     }
 
-    private Map<String, Object> buildTraceBody(Exception exc)
-    {
+    private Map<String, Object> buildTraceChainBody(Exception exc) {
+        Map<String, Object> outterExTrace = (Map<String, Object>)this.buildTraceBody(exc).get('trace');
+        Map<String, Object> innerExTrace = (Map<String, Object>)this.buildTraceBody(exc.getCause()).get('trace');
+
+        List<Map<String, Object>> traceChainList = new List<Map<String, Object>>();
+        traceChainList.add(outterExTrace);
+        traceChainList.add(innerExTrace);
+
+
+        Map<String, Object> body = new Map<String, Object>();
+        body.put('trace_chain', traceChainList);
+
+        return body;
+    }
+
+    private Map<String, Object> buildTraceBody(Exception exc) {
         String stackTraceString = exc.getStackTraceString();
         String typeName = exc.getTypeName();
         String message = exc.getMessage();
 
         return buildTraceBody(stackTraceString, typeName, message);
-
     }
 
     @testVisible
-    private Map<String, Object> buildTraceBody(String stackTraceString, String typeName, String message)
-    {
+    private Map<String, Object> buildTraceBody(
+        String stackTraceString,
+        String typeName,
+        String message
+    ) {
         List<Map<String, Object>> framesList = new List<Map<String, Object>>();
 
         String[] frames = stackTraceString.split('\n');
@@ -225,6 +210,16 @@ public with sharing class DataBuilder {
         body.put('trace', traceMap);
 
         return body;
+    }
+
+    private List<Object> buildTelemetry(Item item) {
+        List<Object> telemetryList = new List<Object>();
+
+        for (Telemetry t : item.telemetry) {
+            telemetryList.add(t.toMap());
+        }
+
+        return telemetryList;
     }
 
     private Config config;

--- a/force-app/main/default/classes/DataBuilder.cls
+++ b/force-app/main/default/classes/DataBuilder.cls
@@ -30,6 +30,9 @@ public with sharing class DataBuilder {
             data.put('custom', item.custom);
         }
 
+        // TODO: if config.personData
+        data.put('person', buildPersonData(item));
+
         return data;
     }
 
@@ -220,6 +223,45 @@ public with sharing class DataBuilder {
         }
 
         return telemetryList;
+    }
+
+    private Map<String, Object> buildPersonData(Item item) {
+        if (item.isUncaught) {
+            // The uncaught error handlers won't have anything meaningful at
+            // UserInfo. Use the provided personId instead.
+            return buildPersonDataFromId(item.personId);
+        }
+
+        return buildCurrentPersonData();
+    }
+
+    private Map<String, Object> buildCurrentPersonData() {
+        Map<String, Object> data = new Map<String, Object>();
+
+        data.put('id', UserInfo.getUserId());
+        data.put('username', UserInfo.getUserName());
+        data.put('email', UserInfo.getUserEmail());
+
+        return data;
+    }
+
+    private Map<String, Object> buildPersonDataFromId(String personId) {
+        Map<String, Object> data = new Map<String, Object>();
+
+        if (personId != null) {
+
+            User u = [
+                SELECT Email, Username FROM User
+                WHERE Id = :personId
+                LIMIT 1
+            ];
+
+            data.put('id', personId);
+            data.put('username', u.Username);
+            data.put('email', u.Email);
+        }
+
+        return data; // return the map whether filled or empty
     }
 
     private Config config;

--- a/force-app/main/default/classes/ExceptionData.cls
+++ b/force-app/main/default/classes/ExceptionData.cls
@@ -51,6 +51,14 @@ global with sharing class ExceptionData {
         return this.environment;
     }
 
+    global String userId() {
+        if (this.userOrg == null) {
+            return null;
+        }
+
+        return this.userOrg.split('/')[0];
+    }
+
     global static ExceptionData fromMap(Map<String, Object> exData) {
         return new ExceptionData(
             (String)exData.get('environment'),

--- a/force-app/main/default/classes/FlowEmailParser.cls
+++ b/force-app/main/default/classes/FlowEmailParser.cls
@@ -1,5 +1,12 @@
 public with sharing class FlowEmailParser {
-    public static List<Telemetry> parseTelemetry(String emailBody) {
+    private String emailBody;
+    public String currentUserId { get; private set; }
+
+    public FlowEmailParser(String emailBody) {
+        this.emailBody =  emailBody;
+    }
+
+    public List<Telemetry> parseTelemetry() {
         List<String> lines = emailBody.split('\n');
 
         return parseLines(lines);
@@ -18,7 +25,7 @@ public with sharing class FlowEmailParser {
     // This parser converts each block into a 'log' telemetry event.
     // Telemetry messages don't render line breaks, so we use punctuation to
     // format the message and improve readability.
-    private static List<Telemetry> parseLines(List<String> lines) {
+    private List<Telemetry> parseLines(List<String> lines) {
         List<Telemetry> telemetryList = new List<Telemetry>();
         Boolean blank = true;
         Boolean prevBlank = true;
@@ -40,6 +47,9 @@ public with sharing class FlowEmailParser {
                 messageLines = new List<String>();
             } else if (!prevBlank && !blank) { // continue block
                 messageLines.add(plain);
+
+                // Assume any internal line might be the user id
+                extractUserId(plain);
             } else { // end block
                 String message = messageFirstLine + String.join(messageLines, ', ');
                 telemetryList.add(addMessage(message));
@@ -50,7 +60,7 @@ public with sharing class FlowEmailParser {
         return telemetryList;
     }
 
-    private static Telemetry addMessage(String message) {
+    private Telemetry addMessage(String message) {
         return new Telemetry(
             'info',
             'log',
@@ -67,11 +77,25 @@ public with sharing class FlowEmailParser {
     //
     // NB: String.stripHtmlTags() is not used, as it is scheduled for deprecation,
     // doesn't remove all tags, and its implementation isn't open for review.
-    private static String stripHtmlTags(String html) {
+    private String stripHtmlTags(String html) {
         String HTML_TAGS = '<[^<>]+>';
         Pattern pattern = Pattern.compile(HTML_TAGS);
         Matcher matcher = pattern.matcher(html);
         return matcher.replaceAll('');
     }
 
+    // Look for the first occurence of a line starting "Current User:",
+    // with the user id in parens. Once an id is found, ignore all
+    // later lines.
+    private Void extractUserId(String line) {
+        if (!String.isBlank(currentUserId)) { return; }
+
+        String CURRENT_USER_PATTERN = 'Current User:.*[(](.*)[)]';
+        Pattern pattern = Pattern.compile(CURRENT_USER_PATTERN);
+
+        Matcher matcher = pattern.matcher(line);
+        if (matcher.matches()) {
+            currentUserId = matcher.group(1);
+        }
+    }
 }

--- a/force-app/main/default/classes/Item.cls
+++ b/force-app/main/default/classes/Item.cls
@@ -1,0 +1,52 @@
+public with sharing class Item {
+    public Item(String message) {
+        this.payloadType = ItemType.MESSAGE;
+        this.message = message;
+    }
+
+    public Item(ExceptionData exData) {
+        this.payloadType = ItemType.EXDATA;
+        this.exData = exData;
+
+        this.custom = new Map<String, Object>();
+        custom.put('context', exData.context());
+    }
+
+    public Item(Exception exc) {
+        this.payloadType = ItemType.EXC;
+        this.exc = exc;
+    }
+
+    public enum ItemType { MESSAGE, EXC, EXDATA }
+
+    public ItemType payloadType { get; private set; }
+    public String message { get; private set; }
+    public ExceptionData exData { get; private set; }
+    public Exception exc { get; private set; }
+
+    public String environment { get; set; }
+    public Map<String, Object> custom { get; set; }
+    public List<Telemetry> telemetry { get; set; }
+    public Boolean isUncaught {
+        get {
+            if (isUncaught == null) {
+                isUncaught = false;
+            }
+
+            return isUncaught;
+        }
+        set;
+    }
+    public String personId { get; set; }
+
+    public Map<String, Object> diagnostic {
+        get {
+            if (diagnostic == null) {
+                diagnostic = new Map<String, Object>();
+            }
+
+            return diagnostic;
+        }
+        private set;
+    }
+}

--- a/force-app/main/default/classes/Item.cls-meta.xml
+++ b/force-app/main/default/classes/Item.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/Notifier.cls
+++ b/force-app/main/default/classes/Notifier.cls
@@ -9,19 +9,10 @@ public with sharing class Notifier
         this.dataBuilder = new DataBuilder(this.config);
     }
 
-    public HttpResponse log(String level, String message, Map<String, Object> custom, List<Telemetry> telemetry, SendMethod method)
-    {
-        return send(dataBuilder.buildPayload(level, message, custom, telemetry), method);
-    }
+    public HttpResponse log(String level, Item item, SendMethod method){
+        item.environment = this.config.environment();
 
-    public HttpResponse log(String level, Exception exc, Map<String, Object> custom, SendMethod method)
-    {
-        return send(dataBuilder.buildPayload(level, exc, custom), method);
-    }
-
-    public HttpResponse log(ExceptionData exData, SendMethod method)
-    {
-        return send(dataBuilder.buildPayload(exData), method);
+        return send(dataBuilder.buildPayload(level, item), method);
     }
 
     public HttpResponse send(Map<String, Object> payload, SendMethod method)

--- a/force-app/main/default/classes/Rollbar.cls
+++ b/force-app/main/default/classes/Rollbar.cls
@@ -43,26 +43,30 @@ global with sharing class Rollbar {
     }
 
     global static HttpResponse log(String level, String message) {
-        return log(level, message, null, null, null);
+        return log(level, message, null, null);
     }
 
     global static HttpResponse log(String level, String message, Map<String, Object> custom) {
-        return log(level, message, custom, null, null);
+        return log(level, message, custom, null);
     }
 
     global static HttpResponse log(String level, String message, SendMethod method) {
-        return log(level, message, null, null, method);
+        return log(level, message, null, method);
     }
 
     global static HttpResponse log(String level, String message, Map<String, Object> custom, SendMethod method) {
-        return log(level, message, custom, null, method);
+        Item item = new Item(message);
+        item.custom = custom;
+
+        return log(level, item, method);
     }
 
-    // Keep this unpublished (public, not global) until Telemetry interface can be frozen,
+    // Keep this unpublished (public, not global) until Item interface can be frozen,
     // which might be never.
-    public static HttpResponse log(String level, String message, Map<String, Object> custom, List<Telemetry> telemetry, SendMethod method) {
+    public static HttpResponse log(String level, Item item, SendMethod method) {
         Rollbar instance = initializedInstance();
-        return instance.notifier.log(level, message, custom, telemetry, method);
+
+        return instance.notifier.log(level, item, method);
     }
 
     global static HttpResponse log(Exception exc) {
@@ -78,13 +82,16 @@ global with sharing class Rollbar {
     }
 
     global static HttpResponse log(Exception exc, Map<String, Object> custom, SendMethod method) {
-        Rollbar instance = initializedInstance();
-        return instance.notifier.log('error', exc, custom, method);
+        Item item = new Item(exc);
+        item.custom = custom;
+
+        return log('error', item, method);
     }
 
     global static HttpResponse log(ExceptionData exData) {
-        Rollbar instance = initializedInstance();
-        return instance.notifier.log(exData, SendMethod.SYNC);
+        Item item = new Item(exData);
+
+        return log('error', item, SendMethod.SYNC);
     }
 
     public static Rollbar initializedInstance()

--- a/force-app/main/default/classes/RollbarConfigureController.cls
+++ b/force-app/main/default/classes/RollbarConfigureController.cls
@@ -6,6 +6,9 @@ public with sharing class RollbarConfigureController {
     public Boolean reportFlowErrors { get; set; }
     public Boolean reportUnknownEmailType { get; set; }
     public Boolean sendReports { get; set; }
+    public Boolean captureUserId { get; set; }
+    public Boolean captureUserName { get; set; }
+    public Boolean captureEmail { get; set; }
     public String environment { get; set; }
     public String accessToken {
         get {
@@ -32,6 +35,9 @@ public with sharing class RollbarConfigureController {
         this.reportUnknownEmailType = this.settings.ReportUnknownEmailType__c;
         this.sendReports = this.settings.SendReports__c;
         this.environment = this.settings.Environment__c;
+        this.captureUserId = this.settings.CaptureUserId__c;
+        this.captureUsername = this.settings.CaptureUsername__c;
+        this.captureEmail = this.settings.CaptureEmail__c;
         updateConfigState();
     }
 
@@ -64,6 +70,9 @@ public with sharing class RollbarConfigureController {
         this.reportFlowErrors = this.settings.ReportFlowErrors__c;
         this.reportUnknownEmailType = this.settings.ReportUnknownEmailType__c;
         this.sendReports = this.settings.SendReports__c;
+        this.captureUserId = this.settings.CaptureUserId__c;
+        this.captureUsername = this.settings.CaptureUsername__c;
+        this.captureEmail = this.settings.CaptureEmail__c;
         this.environment = this.settings.Environment__c;
         updateConfigState();
         return null;
@@ -78,6 +87,9 @@ public with sharing class RollbarConfigureController {
         this.settings.ReportFlowErrors__c = this.reportFlowErrors;
         this.settings.ReportUnknownEmailType__c = this.reportUnknownEmailType;
         this.settings.SendReports__c = this.sendReports;
+        this.settings.CaptureUserId__c = this.captureUserId;
+        this.settings.CaptureUsername__c = this.captureUsername;
+        this.settings.CaptureEmail__c = this.captureEmail;
         this.settings.Environment__c = this.environment;
         upsert this.settings;
 

--- a/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
+++ b/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
@@ -45,21 +45,33 @@ global class RollbarExceptionEmailHandler implements Messaging.InboundEmailHandl
             emailBody = email.plainTextBody;
             ExceptionData exData = ExceptionEmailParser.parse(emailBody);
 
-            Rollbar.log(exData);
+            Item item = new Item(exData);
+            item.isUncaught = true;
+            item.diagnostic.put('emailBody', emailBody);
+
+            Rollbar.log('error', item, SendMethod.SYNC);
         } else if (email.fromName == FlowEmailParser.fromName()) {
             if (!settings.ReportFlowErrors__c) { return; }
 
             emailBody = email.htmlBody;
             List<Telemetry> telemetry = FlowEmailParser.parseTelemetry(emailBody);
 
-            Rollbar.log('error', email.subject, null, telemetry, SendMethod.SYNC);
+            Item item = new Item(email.subject);
+            item.isUncaught = true;
+            item.telemetry = telemetry;
+            item.diagnostic.put('emailBody', emailBody);
+
+            Rollbar.log('error', item, SendMethod.SYNC);
         } else {
             if (!settings.ReportUnknownEmailType__c) { return; }
 
             // Unknown email type.
-            // TODO: Use emailBody and fromName in notifier.diagnostic
+            Item item = new Item(email.subject);
+            item.isUncaught = true;
+            item.diagnostic.put('emailBody', emailBody);
+            item.diagnostic.put('fromName', email.fromName);
 
-            Rollbar.log('error', email.subject, null, null, SendMethod.SYNC);
+            Rollbar.log('error', item, SendMethod.SYNC);
         }
     }
 

--- a/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
+++ b/force-app/main/default/classes/RollbarExceptionEmailHandler.cls
@@ -47,6 +47,7 @@ global class RollbarExceptionEmailHandler implements Messaging.InboundEmailHandl
 
             Item item = new Item(exData);
             item.isUncaught = true;
+            item.personId = exData.userId();
             item.diagnostic.put('emailBody', emailBody);
 
             Rollbar.log('error', item, SendMethod.SYNC);
@@ -54,10 +55,12 @@ global class RollbarExceptionEmailHandler implements Messaging.InboundEmailHandl
             if (!settings.ReportFlowErrors__c) { return; }
 
             emailBody = email.htmlBody;
-            List<Telemetry> telemetry = FlowEmailParser.parseTelemetry(emailBody);
+            FlowEmailParser flowParser = new FlowEmailParser(emailBody);
+            List<Telemetry> telemetry = flowParser.parseTelemetry();
 
             Item item = new Item(email.subject);
             item.isUncaught = true;
+            item.personId = flowParser.currentUserId;
             item.telemetry = telemetry;
             item.diagnostic.put('emailBody', emailBody);
 

--- a/force-app/main/default/objects/RollbarSettings__c/fields/CaptureEmail__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/CaptureEmail__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CaptureEmail__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Capture User Email Address</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/RollbarSettings__c/fields/CaptureUserId__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/CaptureUserId__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CaptureUserId__c</fullName>
+    <defaultValue>true</defaultValue>
+    <externalId>false</externalId>
+    <label>Capture User ID</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/RollbarSettings__c/fields/CaptureUsername__c.field-meta.xml
+++ b/force-app/main/default/objects/RollbarSettings__c/fields/CaptureUsername__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CaptureUsername__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Capture Username</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/pages/RollbarConfigure.page
+++ b/force-app/main/default/pages/RollbarConfigure.page
@@ -224,6 +224,18 @@
                                     <span>Send Events To Rollbar</span>
                                 </p>
                                 <p>
+                                    <apex:inputCheckbox value="{!captureUserId}" label="Capture User ID" />
+                                    <span>Capture User ID</span>
+                                </p>
+                                <p>
+                                    <apex:inputCheckbox value="{!captureUsername}" label="Capture Username" />
+                                    <span>Capture Username</span>
+                                </p>
+                                <p>
+                                    <apex:inputCheckbox value="{!captureEmail}" label="Capture User Email" />
+                                    <span>Capture User Email</span>
+                                </p>
+                                <p>
                                     <h4>Environment</h4>
                                     <apex:inputText value="{!environment}" id="rollbarEnvironment" html-placeholder="Rollbar Environment" />
                                 </p>

--- a/force-app/main/default/tests/DataBuilderTest.cls
+++ b/force-app/main/default/tests/DataBuilderTest.cls
@@ -23,9 +23,18 @@ public class DataBuilderTest
          return u;
     }
 
+    static void insertPersonSettings(Boolean captureUserId, Boolean captureUsername, Boolean captureEmail) {
+        insert new RollbarSettings__c(
+            CaptureUserId__c = captureUserId,
+            CaptureUsername__c = captureUsername,
+            CaptureEmail__c = captureEmail
+        );
+    }
+
     @isTest
     static void testBuildMessagePayload()
     {
+        insertPersonSettings(true, true, true);
         DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
         String expected = 'Message built in DataBuilderTest';
         Item item = new Item(expected);
@@ -59,6 +68,7 @@ public class DataBuilderTest
     @isTest
     static void testBuildMessagePayloadWithTelemetry()
     {
+        insertPersonSettings(true, true, true);
         DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
 
         List<Telemetry> telemetryList = new List<Telemetry>();
@@ -109,6 +119,48 @@ public class DataBuilderTest
         System.assertEquals(messageBody.get('message'), 'first');
         messageBody = (Map<String, String>)telemetryObjects.get(1).get('body');
         System.assertEquals(messageBody.get('message'), 'second');
+    }
+
+    @isTest
+    static void testBuildWithoutPersonCapture()
+    {
+        insertPersonSettings(false, false, false);
+        DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
+        String expected = 'Message built in DataBuilderTest';
+        Item item = new Item(expected);
+
+        User testUser = insertUser('test1');
+        Map<String, Object> result;
+
+        System.runAs(testUser) {
+            result = subject.buildPayload('info', item);
+        }
+
+        Map<String, Object> data = (Map<String, Object>)result.get('data');
+        Map<String, Object> person = (Map<String, Object>)data.get('person');
+        System.assertEquals(null, person);
+    }
+
+    @isTest
+    static void testBuildWithPersonIdOnly()
+    {
+        insertPersonSettings(true, false, false);
+        DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
+        String expected = 'Message built in DataBuilderTest';
+        Item item = new Item(expected);
+
+        User testUser = insertUser('test1');
+        Map<String, Object> result;
+
+        System.runAs(testUser) {
+            result = subject.buildPayload('info', item);
+        }
+
+        Map<String, Object> data = (Map<String, Object>)result.get('data');
+        Map<String, Object> person = (Map<String, Object>)data.get('person');
+        System.assertEquals(testUser.Id, (String)person.get('id'));
+        System.assertEquals(null, (String)person.get('username'));
+        System.assertEquals(null, (String)person.get('email'));
     }
 
     @isTest
@@ -220,6 +272,7 @@ public class DataBuilderTest
     @isTest
     static void testBuildExceptionDataPayload()
     {
+        insertPersonSettings(true, true, true);
         DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
 
         Map<String, Object> expected = new Map<String, Object>();
@@ -273,6 +326,36 @@ public class DataBuilderTest
         System.assertEquals(expected.get('column'), frameMap.get('colno'));
     }
 
+    @isTest
+    static void testUncaughtWithPersonIdOnly()
+    {
+        insertPersonSettings(true, false, false);
+        DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
+
+        Map<String, Object> expected = new Map<String, Object>();
+        expected.put('environment', 'Sandbox');
+        expected.put('organization', 'TestOrg');
+        expected.put('className', 'TestClass');
+        expected.put('message', 'Test exception message');
+        expected.put('fileName', 'Class.ClassWithExceptionThrown.someMethod');
+        expected.put('context', 'Exception context');
+        expected.put('line', 14);
+        expected.put('column', 12);
+
+        ExceptionData exData = ExceptionData.fromMap(expected);
+        Item item = new Item(exData);
+        item.isUncaught = true;
+
+        User testUser = insertUser('test4');
+        item.personId = testUser.Id;
+
+        Map<String, Object> result = subject.buildPayload('error', item);
+        Map<String, Object> data = (Map<String, Object>)result.get('data');
+        Map<String, Object> person = (Map<String, Object>)data.get('person');
+        System.assertEquals(testUser.Id, (String)person.get('id'));
+        System.assertEquals(null, (String)person.get('username'));
+        System.assertEquals(null, (String)person.get('email'));
+    }
     @isTest
     static void testBuildEachFrameType()
     {

--- a/force-app/main/default/tests/DataBuilderTest.cls
+++ b/force-app/main/default/tests/DataBuilderTest.cls
@@ -1,6 +1,28 @@
 @isTest
 public class DataBuilderTest
 {
+    static User insertUser(String userAlias) {
+        Profile p = [SELECT Id FROM Profile WHERE Name='Standard User'];
+        Blob b = Crypto.GenerateAESKey(128);
+        String username = EncodingUtil.ConvertTohex(b) + '@example.com';
+
+        User u = new User(
+            Alias = userAlias,
+            Email = userAlias + '@example.com',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'Tester',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            UserName = username
+        );
+
+         insert(u);
+
+         return u;
+    }
+
     @isTest
     static void testBuildMessagePayload()
     {
@@ -8,9 +30,19 @@ public class DataBuilderTest
         String expected = 'Message built in DataBuilderTest';
         Item item = new Item(expected);
 
-        Map<String, Object> result = subject.buildPayload('info', item);
+        User testUser = insertUser('test1');
+        Map<String, Object> result;
+
+        System.runAs(testUser) {
+            result = subject.buildPayload('info', item);
+        }
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
+
+        Map<String, Object> person = (Map<String, Object>)data.get('person');
+        System.assertEquals(testUser.Id, (String)person.get('id'));
+        System.assertEquals(testUser.Username, (String)person.get('username'));
+        System.assertEquals(testUser.Email, (String)person.get('email'));
 
         System.assertEquals(data.containsKey('custom'), false);
 
@@ -46,10 +78,20 @@ public class DataBuilderTest
         ));
         Item item = new Item('Telemetry test');
         item.telemetry = telemetryList;
+        item.isUncaught = true; // Make item look like a Flow error
+
+        User testUser = insertUser('test2');
+        item.personId = testUser.Id;
 
         Map<String, Object> result = subject.buildPayload('info', item);
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
+
+        Map<String, Object> person = (Map<String, Object>)data.get('person');
+        System.assertEquals(testUser.Id, (String)person.get('id'));
+        System.assertEquals(testUser.Username, (String)person.get('username'));
+        System.assertEquals(testUser.Email, (String)person.get('email'));
+
         Map<String, Object> body = (Map<String, Object>)data.get('body');
 
         List<Map<String, Object>> telemetryObjects = new List<Map<String, Object>>();
@@ -192,6 +234,10 @@ public class DataBuilderTest
 
         ExceptionData exData = ExceptionData.fromMap(expected);
         Item item = new Item(exData);
+        item.isUncaught = true;
+
+        User testUser = insertUser('test3');
+        item.personId = testUser.Id;
 
         Map<String, Object> result = subject.buildPayload('error', item);
 
@@ -200,6 +246,11 @@ public class DataBuilderTest
         Map<String, Object> custom = (Map<String, Object>)data.get('custom');
 
         System.assertEquals((String)expected.get('context'), (String)custom.get('context'));
+
+        Map<String, Object> person = (Map<String, Object>)data.get('person');
+        System.assertEquals(testUser.Id, (String)person.get('id'));
+        System.assertEquals(testUser.Username, (String)person.get('username'));
+        System.assertEquals(testUser.Email, (String)person.get('email'));
 
         Map<String, Object> notifierMap = (Map<String, Object>)data.get('notifier');
         System.assertEquals(Notifier.NAME, (String)notifierMap.get('name'));

--- a/force-app/main/default/tests/DataBuilderTest.cls
+++ b/force-app/main/default/tests/DataBuilderTest.cls
@@ -6,8 +6,9 @@ public class DataBuilderTest
     {
         DataBuilder subject = new DataBuilder(new Config('foo', 'bar'));
         String expected = 'Message built in DataBuilderTest';
+        Item item = new Item(expected);
 
-        Map<String, Object> result = subject.buildPayload('info', expected, null, null);
+        Map<String, Object> result = subject.buildPayload('info', item);
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
 
@@ -43,8 +44,10 @@ public class DataBuilderTest
             987654321,
             new Map<String, String>{ 'message' => 'second' }
         ));
+        Item item = new Item('Telemetry test');
+        item.telemetry = telemetryList;
 
-        Map<String, Object> result = subject.buildPayload('info', 'Telemetry test', null, telemetryList);
+        Map<String, Object> result = subject.buildPayload('info', item);
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
         Map<String, Object> body = (Map<String, Object>)data.get('body');
@@ -85,7 +88,8 @@ public class DataBuilderTest
             expectedClass = exc.getTypeName();
             throw exc;
         } catch(Exception exc) {
-            Map<String, Object> result = subject.buildPayload('error', exc, null);
+            Item item = new Item(exc);
+            Map<String, Object> result = subject.buildPayload('error', item);
 
             Map<String, Object> data = (Map<String, Object>)result.get('data');
 
@@ -117,8 +121,10 @@ public class DataBuilderTest
         expectedCustom.put('foo', 'bar');
 
         DataBuilderTestException exc = new DataBuilderTestException('foobar');
+        Item item = new Item(exc);
+        item.custom = expectedCustom;
 
-        Map<String, Object> result = subject.buildPayload('error', exc, expectedCustom);
+        Map<String, Object> result = subject.buildPayload('error', item);
         Map<String, Object> data = (Map<String, Object>)result.get('data');
         Map<String, Object> custom = (Map<String, Object>)data.get('custom');
 
@@ -144,8 +150,9 @@ public class DataBuilderTest
             }
         } catch(Exception exc1) {
             expectedClass1 = exc1.getTypeName();
+            Item item = new Item(exc1);
 
-            Map<String, Object> result = subject.buildPayload('error', exc1, null);
+            Map<String, Object> result = subject.buildPayload('error', item);
 
             Map<String, Object> data = (Map<String, Object>)result.get('data');
 
@@ -184,8 +191,9 @@ public class DataBuilderTest
         expected.put('column', 12);
 
         ExceptionData exData = ExceptionData.fromMap(expected);
+        Item item = new Item(exData);
 
-        Map<String, Object> result = subject.buildPayload(exData);
+        Map<String, Object> result = subject.buildPayload('error', item);
 
         Map<String, Object> data = (Map<String, Object>)result.get('data');
 

--- a/force-app/main/default/tests/ExceptionEmailParserTest.cls
+++ b/force-app/main/default/tests/ExceptionEmailParserTest.cls
@@ -14,6 +14,7 @@ public class ExceptionEmailParserTest {
 
         System.assertEquals(null, exData.environment());
         System.assertEquals('0050R000001t3Br/00D0R000000DUxZ', exData.userOrg());
+        System.assertEquals('0050R000001t3Br', exData.userId());
         System.assertEquals('System.NullPointerException', exData.className());
         System.assertEquals('Attempt to de-reference a null object', exData.message());
         System.assertEquals('Trigger.ContactEx', exData.fileName());
@@ -35,6 +36,7 @@ public class ExceptionEmailParserTest {
 
         System.assertEquals(null, exData.environment());
         System.assertEquals('0050R000001t3Br/00D0R000000DUxZ', exData.userOrg());
+        System.assertEquals('0050R000001t3Br', exData.userId());
         System.assertEquals('System.NullPointerException', exData.className());
         System.assertEquals('Attempt to de-reference a null object', exData.message());
         System.assertEquals('Trigger.ContactEx', exData.fileName());
@@ -56,6 +58,7 @@ public class ExceptionEmailParserTest {
         ExceptionData exData = ExceptionEmailParser.parse(emailBody);
 
         System.assertEquals('0050R000001t3Br/00D0R000000DUxZ', exData.userOrg());
+        System.assertEquals('0050R000001t3Br', exData.userId());
         System.assertEquals('System.DmlException', exData.className());
         System.assertEquals('Delete failed. First exception on row 5 with id b4r2E000001ReGSQB0; first error: ENTITY_IS_DELETED, entity is deleted: []', exData.message());
         System.assertEquals('Source organization: 00D0R000000DUxZ (null)\nFailed to process batch for class \'ccrz.ccProductIndexCleanupJob\' for job id \'8061F00001btixO\'', exData.context());
@@ -70,6 +73,7 @@ public class ExceptionEmailParserTest {
         ExceptionData exData = ExceptionEmailParser.parse(emailBody);
 
         System.assertEquals('0050R000001t3Br/00D0R000000DUxZ', exData.userOrg());
+        System.assertEquals('0050R000001t3Br', exData.userId());
         System.assertEquals('Failed to process batch for class \'G2Crowd.CalculateAccountAveragesBatch\' for job id \'8061F00001btixO\'', exData.context());
     }
 
@@ -81,6 +85,7 @@ public class ExceptionEmailParserTest {
         ExceptionData exData = ExceptionEmailParser.parse(emailBody);
 
         System.assertEquals(null, exData.userOrg());
+        System.assertEquals(null, exData.userId());
         System.assertEquals('Unknown Error', exData.message());
         System.assertEquals('Failed to process batch for class \'G2Crowd.CalculateAccountAveragesBatch\' for job id \'8061F00001btixO\'', exData.context());
     }

--- a/force-app/main/default/tests/FlowEmailParserTest.cls
+++ b/force-app/main/default/tests/FlowEmailParserTest.cls
@@ -34,7 +34,8 @@ public class FlowEmailParserTest {
 
     @isTest
     public static void testParse() {
-        List<Telemetry> telemetryList = FlowEmailParser.parseTelemetry(emailBody);
+        FlowEmailParser flowParser = new FlowEmailParser(emailBody);
+        List<Telemetry> telemetryList = flowParser.parseTelemetry();
 
         System.assertEquals(telemetryList.size(), 4);
 
@@ -54,5 +55,7 @@ public class FlowEmailParserTest {
         // Confirm handling of unexpected <>
         System.assert(telemetryList.get(1).body.get('message').contains('Change Process'));
         System.assert(telemetryList.get(1).body.get('message').contains('<>'));
+
+        System.assertEquals(flowParser.currentUserId, '0056g0000067Oja');
     }
 }

--- a/force-app/main/default/tests/NotifierTest.cls
+++ b/force-app/main/default/tests/NotifierTest.cls
@@ -8,9 +8,10 @@ public class NotifierTest {
         Config config = new Config('foo', 'bar');
 
         Notifier subject = new Notifier(config);
+        Item item = new Item('Message from the Apex SDK');
 
         Test.startTest();
-        HttpResponse response = subject.log('info', 'Message from the Apex SDK', null, null, SendMethod.SYNC);
+        HttpResponse response = subject.log('info', item, SendMethod.SYNC);
         Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
@@ -36,11 +37,11 @@ public class NotifierTest {
         Config config = new Config('foo', 'bar');
 
         Notifier subject = new Notifier(config);
-
         DataBuilderTestException exc = new DataBuilderTestException();
+        Item item = new Item(exc);
 
         Test.startTest();
-        HttpResponse response = subject.log('error', exc, null, SendMethod.SYNC);
+        HttpResponse response = subject.log('error', item, SendMethod.SYNC);
         Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
@@ -78,9 +79,10 @@ public class NotifierTest {
         expected.put('column', 12);
 
         ExceptionData exData = ExceptionData.fromMap(expected);
+        Item item = new Item(exData);
 
         Test.startTest();
-        HttpResponse response = subject.log(exData, SendMethod.SYNC);
+        HttpResponse response = subject.log('error', item, SendMethod.SYNC);
         Test.stopTest();
 
         System.assertEquals(200, response.getStatusCode());
@@ -106,9 +108,10 @@ public class NotifierTest {
         Config config = new Config('foo', 'bar');
 
         Notifier subject = new Notifier(config);
+        Item item = new Item('Message from the Apex SDK');
 
         Test.startTest();
-        HttpResponse response = subject.log('info', 'Message from the Apex SDK', null, null, SendMethod.SYNC);
+        HttpResponse response = subject.log('info', item, SendMethod.SYNC);
         Test.stopTest();
 
         System.assertEquals(response, null);

--- a/force-app/main/default/tests/RollbarTest.cls
+++ b/force-app/main/default/tests/RollbarTest.cls
@@ -41,13 +41,12 @@ public class RollbarTest {
     }
 
     @isTest
-    public static void testLogMessageWithCustomDataAndTelemetry() {
+    public static void testLogMessageWithCustomData() {
         RollbarTestHelper.setDefaultMock();
 
         insert new RollbarSettings__c(SendReports__c = true);
 
         Map<String, Object> customData = new Map<String, Object>{ 'foo' => 'bar' };
-        List<Telemetry> telemetryList = new List<Telemetry>();
 
         Test.startTest();
         Rollbar.init('test-token', 'test-env');
@@ -55,7 +54,6 @@ public class RollbarTest {
             'info',
             'Message from the Apex SDK',
             customData,
-            telemetryList,
             SendMethod.SYNC
         );
         Test.stopTest();

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -11,6 +11,7 @@
         <members>ExceptionEmailParser</members>
         <members>ExceptionEmailParsingException</members>
         <members>FlowEmailParser</members>
+        <members>Item</members>
         <members>MetadataService</members>
         <members>Notifier</members>
         <members>Rollbar</members>


### PR DESCRIPTION
## Description of the change

The motivation for this PR is to add person data (current user) as supported in other Rollbar SDKs. This PR also includes refactoring to use an `Item` class to manage setting up the occurrence, as is done in most or all of the other SDKs.

The original, minimal implementation of this SDK didn't use an Item class, and any data, flags or modifiers of the payload needed to be passed through as method arguments. As more optional data elements have been added, e.g. custom data, telemetry, and now person data, this arrangement has been stretched to its limit and keeping everything in an Item class is a much needed simplification. 

This is a relatively large PR, but is cleanly divided into commits that can each be reviewed separately:
- [x] refactor to use Item class, and set notfier.diagnostic key in payload
- [x] extract user id from Flow and Exception emails
- [x] add person data to payload, either via item.personId or current user
- [x] add config settings to enable/disable person id, username, email

**Person data in Salesforce:**
Salesforce allows using the `UserInfo` service to get the current user in most contexts. This does not work when processing unhandled Exceptions and Flow errors, as these run outside the user's context. In those cases, the user id is extracted from the error data and used to perform a DML lookup (essentially a database query).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes ch73809

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
